### PR TITLE
Quickstart with docker-compose

### DIFF
--- a/api/server/swagger_server/data_access/minio_client.py
+++ b/api/server/swagger_server/data_access/minio_client.py
@@ -225,7 +225,7 @@ def _update_bucket_policy(bucket_name: str, prefix: str):
     except NoSuchBucketPolicy:
         bucket_policy = dict(_bucket_policy_template)
 
-    getobject_stmts = [s for s in bucket_policy["Statement"] if s["Sid"] == _bucket_policy_sid] or \
+    getobject_stmts = [s for s in bucket_policy["Statement"] if s.get("Sid") == _bucket_policy_sid] or \
                       [s for s in bucket_policy["Statement"] if "s3:GetObject" in s["Action"]]
 
     if not getobject_stmts:

--- a/api/server/swagger_server/data_access/mysql_client.py
+++ b/api/server/swagger_server/data_access/mysql_client.py
@@ -685,6 +685,12 @@ def load_data(swagger_class: type, filter_dict: dict = None, sort_by: str = None
         cursor.execute(query)
 
         swagger_attr_names = [_convert_col_name_to_attr_name(c) for c in cursor.column_names]
+
+        assert set(swagger_attr_names) <= set(sig.parameters.keys()), \
+            f"Mismatch between database schema and API spec for {table_name}. " \
+            f"Expected columns: {[_convert_attr_name_to_col_name(k) for k in sig.parameters.keys() if k != 'self']}. " \
+            f"Database columns: {cursor.column_names}"
+
         swagger_attr_types = [sig.parameters.get(a).annotation for a in swagger_attr_names]
 
         for row_values in cursor:

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,0 +1,52 @@
+# Running MLX with Docker Compose
+
+This _"quickstart"_ setup uses Docker Compose to bring up the MLX-API server and
+the MLX Dashboard, along with the MySQL database and Minio S3 storage backend.
+In this configuration, the preloaded asset catalog of Components, Datasets, Models
+and Notebooks can be browsed, asset metadata and sample code can be downloaded
+and new assets can be registered. Sample pipeline code can be generated for each
+asset type, their execution on a Kubeflow Pipelines cluster is not enabled however.
+
+## Limitations
+
+The _Pipelines_ and _Inference Service_ capabilities are not available with this
+Docker Compose setup. 
+
+## Prerequisites
+
+Install [Docker Compose](https://docs.docker.com/compose/install/).
+
+## Pull the Docker Images
+
+    docker compose pull
+
+## Bring up the Docker Containers
+
+    docker compose up
+
+Wait for the containers to start up. When the MLX API and UI are ready, this
+message should show up in the terminal log:
+
+```Markdown
+dashboard_1   | 
+dashboard_1   | ================================================
+dashboard_1   |  Open the MLX Dashboard at http://localhost:80/ 
+dashboard_1   | ================================================
+dashboard_1   | 
+```
+
+Now open a web browser and type `localhost` in the address bar to open the MLX
+dashboard.
+
+The MLX API spec can be explored at `localhost:8080/apis/v1alpha1/ui/`
+
+
+## Shut Down the Docker Containers
+
+Press `control` + `c` on the Terminal to stop and then remove the containers:
+
+    docker compose down -v
+
+## Remove the Data Created by Minio and MySQL
+
+    docker volume prune -f

--- a/quickstart/catalog_upload.json
+++ b/quickstart/catalog_upload.json
@@ -1,0 +1,155 @@
+{
+  "components": [
+    {
+      "name": "Train Spark Model - IBM Cloud",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/spark/train_spark/component.yaml"
+    },
+    {
+      "name": "Serve PyTorch Model - Seldon Core",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/ffdl/serve/component.yaml"
+    },
+    {
+      "name": "Deploy Model - Watson Machine Learning",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/deploy/component.yaml"
+    },
+    {
+      "name": "Echo",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/echo/echo.yaml"
+    },
+    {
+      "name": "Model Robustness Check - PyTorch",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/metrics/robustness_checker/component.yaml"
+    },
+    {
+      "name": "Model Fairness Check - PyTorch",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/metrics/bias_detector/component.yaml"
+    },
+    {
+      "name": "Deploy Model - Kubernetes",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/kubernetes/kube_deployment/component.yaml"
+    },
+    {
+      "name": "Deploy Model - KFServing",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kubeflow/kfserving/component.yaml"
+    },
+    {
+      "name": "Subscribe - Watson OpenScale",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/manage/subscribe/component.yaml"
+    },
+    {
+      "name": "Store model - Watson Machine Learning",
+      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/store/component.yaml"
+    },
+    {
+      "name": "Jupyter",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/jupyter/component.yaml"
+    },
+    {
+      "name": "Generate Dataset Metadata",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/dax-to-dlf/component.yaml"
+    },
+    {
+      "name": "Create Dataset Volume",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/dlf/component.yaml"
+    }
+  ],
+  "datasets": [
+    {
+      "name": "Thematic Clustering",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/thematic_clustering.yaml"
+    },
+    {
+      "name": "Finance Proposition Bank",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/fpb.yaml"
+    },
+    {
+      "name": "Groningen Meaning Bank",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/gmb.yaml"
+    },
+    {
+      "name": "NOAA Weather Data",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/jfk.yaml"
+    },
+    {
+      "name": "PubLayNet",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/publaynet.yaml"
+    },
+    {
+      "name": "PubTabNet",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/pubtabnet.yaml"
+    },
+    {
+      "name": "TensorFlow Speech Commands",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/tsc.yaml"
+    }
+  ],
+  "models": [
+    {
+      "name": "MAX Human Pose Estimator",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-human-pose-estimator.yaml"
+    },
+    {
+      "name": "MAX Image Resolution Enhancer",
+      "url": "https://github.com/machine-learning-exchange/katalog/blob/main/model-samples/max-image-resolution-enhancer.yaml"
+    },
+    {
+      "name": "MAX Optical Character Recognition",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-ocr.yaml"
+    },
+    {
+      "name": "MAX Image Caption Generator",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-image-caption-generator.yaml"
+    },
+    {
+      "name": "MAX Toxic Comment Classifier",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-toxic-comment-classifier.yaml"
+    },
+    {
+      "name": "MAX Question Answering",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-question-answering.yaml"
+    },
+    {
+      "name": "MAX Recommender System",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-recommender.yaml"
+    },
+    {
+      "name": "MAX Object Detector",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-object-detector.yaml"
+    },
+    {
+      "name": "MAX Text Sentiment Classifier",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-text-sentiment-classifier.yaml"
+    },
+    {
+      "name": "MAX Weather Forecaster",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/model-samples/max-weather-forecaster.yaml"
+    }
+  ],
+  "notebooks": [
+    {
+      "name": "AIF360 Gender Classification",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/aif360-gender.yaml"
+    },
+    {
+      "name": "ART detector model",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/art-detector.yaml"
+    },
+    {
+      "name": "ART poisoning attack",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/art-poison.yaml"
+    },
+    {
+      "name": "AIF360 Bias detection example",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/aif-bias.yaml"
+    },
+    {
+      "name": "JFK Airport Analysis",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/JFK-airport.yaml"
+    },
+    {
+      "name": "Train and deploy with Watson Machine Learning",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/watson-ml.yaml"
+    }
+  ],
+  "pipelines": []
+}

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -1,0 +1,110 @@
+version: '3.7'
+
+# starts 4 Docker containers: Minio, MySQL, MLX-API, MLX-UI
+# access the MLX API Spec at http://localhost:8080/apis/v1alpha1/ui/#!/
+# access the MLX UI dashboard at http://localhost/
+
+services:
+
+  minio:
+    image: minio/minio
+    volumes:
+      - data-minio:/data
+    ports:
+      - "9000:9000"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    command: server /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  miniosetup:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: ["/bin/sh","-c"]
+    command:
+    - |
+      /usr/bin/mc config host add miniohost http://minio:9000 minio minio123
+      /usr/bin/mc mb -p miniohost/mlpipeline
+      /usr/bin/mc policy set download miniohost/mlpipeline
+
+  mysql:
+    image: mysql:5.7
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_DATABASE: "mlpipeline"
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
+      - data-mysql:/var/lib/mysql
+
+  mlx-api:
+    image: mlexchange/mlx-api:0.1.25
+    volumes:
+      - data-mlx-api:/data
+    ports:
+      - "8080:8080"
+    environment:
+      MINIO_SERVICE_SERVICE_HOST: "minio"
+      MINIO_SERVICE_SERVICE_PORT: "9000"
+      MYSQL_SERVICE_HOST: "mysql"
+      MYSQL_SERVICE_PORT: "3306"
+      ML_PIPELINE_UI_SERVICE_HOST: "UNAVAILABLE"
+      ML_PIPELINE_UI_SERVICE_PORT: "UNAVAILABLE"
+
+  mlx-ui:
+#    image: aipipeline/mlx-ui:nightly-origin-main
+    image: mlexchange/mlx-ui:2021.05.06
+    volumes:
+      - data-mlx-ui:/data
+    ports:
+      - "80:3000"
+    environment:
+      REACT_APP_BRAND: "Machine Learning Exchange"
+      REACT_APP_RUN: "true"
+      REACT_APP_UPLOAD: "true"
+      REACT_APP_BASE_PATH: ""
+      REACT_APP_API: "localhost:8080"
+      REACT_APP_KFP: ""
+
+  catalog:
+    image: curlimages/curl
+    depends_on:
+      - minio
+      - mysql
+      - mlx-api
+    volumes:
+      - ./catalog_upload.json:/catalog_upload.json
+      - ./init_catalog.sh:/init_catalog.sh
+    entrypoint: ["/bin/sh", "-c", "/init_catalog.sh"]
+    environment:
+      MLX_API_SERVER: "mlx-api:8080"
+
+  dashboard:
+    image: curlimages/curl
+    depends_on:
+      - mlx-ui
+      - mlx-init
+    entrypoint: ["/bin/sh","-c"]
+    command:
+    - |
+      until curl -I -s "http://mlx-ui:3000" | grep -q "200 OK"; do sleep 5; done
+      echo
+      echo "================================================"
+      echo " Open the MLX Dashboard at http://localhost:80/ "
+      echo "================================================"
+      echo
+
+volumes:
+  data-minio:
+  data-mysql:
+  data-mlx-api:
+  data-mlx-ui:

--- a/quickstart/init_catalog.sh
+++ b/quickstart/init_catalog.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+MLX_API_SERVER=${MLX_API_SERVER:-"localhost:8080"}
+MLX_API_URL="http://${MLX_API_SERVER}/apis/v1alpha1"
+
+# wait for the MLX API server, but more importantly the MySQL server to be ready
+until curl -X GET -H 'Accept: application/json' -s "${MLX_API_URL}/health_check?check_database=true&check_object_store=true" | grep -q 'Healthy'; do
+  echo 'Waiting for MLX-API, Minio, MySQL ...'
+  sleep 1
+done
+
+# echo the MLX API server status, should be "Healthy"
+curl -X GET -H 'Accept: application/json' -s "${MLX_API_URL}/health_check?check_database=true&check_object_store=true"
+
+# upload the pipeline asset catalog
+curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d @catalog_upload.json -s "${MLX_API_URL}/catalog"
+
+# mark all the catalog assets as approved and featured
+for asset_type in components datasets models notebooks; do
+  curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/publish_approved"
+  curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/featured"
+done
+
+# disable the Pipelines page, since we don't have a KFP cluster
+curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Pipelines": false}' -s "${MLX_API_URL}/settings"

--- a/quickstart/init_db.sql
+++ b/quickstart/init_db.sql
@@ -1,0 +1,42 @@
+-- ---------------------------------------------
+-- Generated using MySQL dump
+-- Server version: 5.7.33
+-- Database: mlpipeline
+-- ---------------------------------------------
+-- $ brew install mysql-client
+-- $ /usr/local/opt/mysql-client/bin/mysqldump mlpipeline --result-file=init_db.sql pipelines pipeline_versions --skip-add-drop-table --skip-disable-keys --skip-lock-tables --skip-add-locks --create-options --extended-insert --column-statistics=0 --user=root --host=169.45.121.104 --port=32259
+-- ---------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `pipelines` (
+  `UUID` varchar(255) NOT NULL,
+  `CreatedAtInSec` bigint(20) NOT NULL,
+  `Name` varchar(255) NOT NULL,
+  `Description` longtext NOT NULL,
+  `Parameters` longtext NOT NULL,
+  `Status` varchar(255) NOT NULL,
+  `DefaultVersionId` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`UUID`),
+  UNIQUE KEY `name_index` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE TABLE IF NOT EXISTS `pipeline_versions` (
+  `UUID` varchar(255) NOT NULL,
+  `CreatedAtInSec` bigint(20) NOT NULL,
+  `Name` varchar(255) NOT NULL,
+  `Parameters` longtext NOT NULL,
+  `PipelineId` varchar(255) NOT NULL,
+  `Status` varchar(255) NOT NULL,
+  `CodeSourceUrl` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`UUID`),
+  UNIQUE KEY `idx_pipelineid_name` (`Name`,`PipelineId`),
+  KEY `idx_pipeline_versions_CreatedAtInSec` (`CreatedAtInSec`),
+  KEY `idx_pipeline_versions_PipelineId` (`PipelineId`),
+  CONSTRAINT `pipeline_versions_PipelineId_pipelines_UUID_foreign` FOREIGN KEY (`PipelineId`) REFERENCES `pipelines` (`UUID`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- don't populate tables since we won't have the accompanying "template" YAML stored on Minio
+--
+
+-- INSERT INTO `pipelines` VALUES ('c616527f-1f3c-4f0c-aada-35fa2cc4feb3',1619547888,'[Demo] flip-coin','[source code](https://github.com/kubeflow/kfp-tekton/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.','[]','READY','c616527f-1f3c-4f0c-aada-35fa2cc4feb3');
+-- INSERT INTO `pipeline_versions` VALUES ('c616527f-1f3c-4f0c-aada-35fa2cc4feb3',1619547888,'[Demo] flip-coin','[]','c616527f-1f3c-4f0c-aada-35fa2cc4feb3','READY','');


### PR DESCRIPTION
# Running MLX with Docker Compose

This _"quickstart"_ setup uses Docker Compose to bring up the MLX-API server and
the MLX Dashboard, along with the MySQL database and Minio S3 storage backend.
In this configuration, the preloaded asset catalog of Components, Datasets, Models
and Notebooks can be browsed, asset metadata and sample code can be downloaded
and new assets can be registered. Sample pipeline code can be generated for each
asset type, their execution on a Kubeflow Pipelines cluster is not enabled however.

## Limitations

The _Pipelines_ and _Inference Service_ capabilities are not available with this
Docker Compose setup. 

## Prerequisites

Install [Docker Compose](https://docs.docker.com/compose/install/).

## Pull the Docker Images

    docker compose pull

## Bring up the Docker Containers

    docker compose up

Wait for the containers to start up. When the MLX API and UI are ready, this
message should show up in the terminal log:

```Markdown
dashboard_1   | 
dashboard_1   | ================================================
dashboard_1   |  Open the MLX Dashboard at http://localhost:80/ 
dashboard_1   | ================================================
dashboard_1   | 
```

Now open a web browser and type `localhost` in the address bar to open the MLX
dashboard.

The MLX API spec can be explored at `localhost:8080/apis/v1alpha1/ui/`


## Shut Down the Docker Containers

Press `control` + `c` on the Terminal to stop and then remove the containers:

    docker compose down -v

## Remove the Data Created by Minio and MySQL

    docker volume prune -f
