### PR TITLE
Run docker-compose on remote machine

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -48,6 +48,13 @@ dashboard.
 
 The MLX API spec can be explored at `localhost:8080/apis/v1alpha1/ui/`
 
+**Note:** If the Docker compose stack is running on a remote host, and the
+MLX Web UI is running on `localhost`, export the environment
+variable `DOCKER_HOST_IP`, so that the MLX UI web app on `localhost` can connect
+to the MLX API on the Docker host.
+
+    export DOCKER_HOST_IP=127.0.0.1
+    docker compose up
 
 ## Shut Down the Docker Containers
 

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -59,7 +59,6 @@ services:
       ML_PIPELINE_UI_SERVICE_PORT: "UNAVAILABLE"
 
   mlx-ui:
-#    image: aipipeline/mlx-ui:nightly-origin-main
     image: mlexchange/mlx-ui:2021.05.06
     ports:
       - "80:3000"
@@ -68,7 +67,7 @@ services:
       REACT_APP_RUN: "true"
       REACT_APP_UPLOAD: "true"
       REACT_APP_BASE_PATH: ""
-      REACT_APP_API: "localhost:8080"
+      REACT_APP_API: "${DOCKER_HOST_IP:-localhost}:8080"
       REACT_APP_KFP: ""
 
   catalog:
@@ -95,7 +94,7 @@ services:
       until curl -I -s "http://mlx-ui:3000" | grep -q "200 OK"; do sleep 5; done
       echo
       echo "================================================"
-      echo " Open the MLX Dashboard at http://localhost:80/ "
+      echo " Open the MLX Dashboard at http://${DOCKER_HOST_IP:-localhost}:80/ "
       echo "================================================"
       echo
 


### PR DESCRIPTION
Follow up to PR #25 

If the Docker compose stack is running on a remote host, and the
MLX Web UI is running on `localhost`, export the environment
variable `DOCKER_HOST_IP`, so that the MLX UI web app running
on `localhost` can connect to the MLX API running on the Docker host.

    export DOCKER_HOST_IP=127.0.0.1
    docker compose up


@romeokienzler 

Resolves #26