### PR TITLE
[WIP] Add kfp-api to quickstart with docker-compose

### DIFF
--- a/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
+++ b/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
@@ -72,6 +72,8 @@ def upload_pipeline_to_kfp(uploadfile: str, name: str = None) -> ApiPipeline:
     api_instance = PipelineUploadServiceApi(api_client=api_client)
 
     try:
+        print(f"Calling PipelineServiceApi ({_pipeline_service_url}) -> upload_pipeline(name='{name}')")
+
         kfp_pipeline: KfpPipeline = api_instance.upload_pipeline(uploadfile=uploadfile, name=name)
         api_pipeline: ApiPipeline = ApiPipeline.from_dict(kfp_pipeline.to_dict())
         api_pipeline.status = kfp_pipeline.error

--- a/quickstart/catalog_upload.json
+++ b/quickstart/catalog_upload.json
@@ -151,5 +151,22 @@
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/watson-ml.yaml"
     }
   ],
-  "pipelines": []
+  "pipelines": [
+    {
+      "name": "Parallel Join",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/parallel_join.yaml"
+    },
+    {
+      "name": "Sequential Pipeline",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/sequential.yaml"
+    },
+    {
+      "name": "Launch a Katib experiment",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/katib.yaml"
+    },
+    {
+      "name": "ResourceOp Basic",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/resourceop_basic.yaml"
+    }
+  ]
 }

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -46,6 +46,38 @@ services:
       - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
       - data-mysql:/var/lib/mysql
 
+  kfp-api:
+    image: aipipeline/api-server:0.7.0
+    environment:
+      DBCONFIG_HOST: "mysql"
+      DBCONFIG_PORT: "3306"
+#      DBCONFIG_USER: "root"
+#      DBCONFIG_PASSWORD: ""
+#      DBCONFIG_DBNAME: "mlpipeline"
+      MINIO_SERVICE_SERVICE_HOST: "minio"
+      MINIO_SERVICE_SERVICE_PORT: "9000"
+#      MINIO_PIPELINE_BUCKET_NAME: "mlpipeline"
+#      MINIO_PIPELINE_PATH: ""
+      KUBERNETES_SERVICE_HOST: "localhost"
+      KUBERNETES_SERVICE_PORT: "443"
+      OBJECTSTORECONFIG_ACCESSKEY: "minio"
+      OBJECTSTORECONFIG_BUCKETNAME: "mlpipeline"
+      OBJECTSTORECONFIG_SECRETACCESSKEY: "minio123"
+      OBJECTSTORECONFIG_SECURE: "false"
+      ARTIFACT_BUCKET: "mlpipeline"
+      ARTIFACT_ENDPOINT: "minio:9000"
+      ARTIFACT_ENDPOINT_SCHEME: "http://"
+      ARTIFACT_IMAGE: "minio/mc"
+      HOSTNAME: "kfp-api"
+    ports:
+      - "8888:8888"  # http
+      - "8887:8887"  # grpc
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "-S", "-O", "-", "http://localhost:8888/apis/v1beta1/healthz" ]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
   mlx-api:
     image: mlexchange/mlx-api:0.1.25
     ports:
@@ -55,8 +87,8 @@ services:
       MINIO_SERVICE_SERVICE_PORT: "9000"
       MYSQL_SERVICE_HOST: "mysql"
       MYSQL_SERVICE_PORT: "3306"
-      ML_PIPELINE_UI_SERVICE_HOST: "UNAVAILABLE"
-      ML_PIPELINE_UI_SERVICE_PORT: "UNAVAILABLE"
+      ML_PIPELINE_UI_SERVICE_HOST: "kfp-api"
+      ML_PIPELINE_UI_SERVICE_PORT: "8888"
 
   mlx-ui:
 #    image: aipipeline/mlx-ui:nightly-origin-main
@@ -69,13 +101,14 @@ services:
       REACT_APP_UPLOAD: "true"
       REACT_APP_BASE_PATH: ""
       REACT_APP_API: "localhost:8080"
-      REACT_APP_KFP: ""
+      REACT_APP_KFP: "localhost:8888"
 
   catalog:
     image: curlimages/curl
     depends_on:
       - minio
       - mysql
+      - kfp-api
       - mlx-api
     volumes:
       - ./catalog_upload.json:/catalog_upload.json

--- a/quickstart/init_catalog.sh
+++ b/quickstart/init_catalog.sh
@@ -16,13 +16,13 @@ curl -X GET -H 'Accept: application/json' -s "${MLX_API_URL}/health_check?check_
 curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d @catalog_upload.json -s "${MLX_API_URL}/catalog" | grep "total_"
 
 # mark all the catalog assets as approved and featured
-for asset_type in components datasets models notebooks; do
+for asset_type in components datasets models notebooks pipelines; do
   curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/publish_approved"
   curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/featured"
 done
 
-# disable the Pipelines page, since we don't have a KFP cluster
-curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Pipelines": false}' -s "${MLX_API_URL}/settings" -o /dev/null --show-error
+## disable the Pipelines page, since we don't have a KFP cluster
+#curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Pipelines": false}' -s "${MLX_API_URL}/settings"
 
 # disable the Inference Services page, since we don't have a KFP cluster
 curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Inference Services": false}' -s "${MLX_API_URL}/settings" -o /dev/null --show-error


### PR DESCRIPTION
Adding the kfp(-tekton)-api to the quickstart with docker compose. 

```YAML
  kfp-api:
    image: aipipeline/api-server:0.7.0
    environment:
      DBCONFIG_HOST: "mysql"
      DBCONFIG_PORT: "3306"
      MINIO_SERVICE_SERVICE_HOST: "minio"
      MINIO_SERVICE_SERVICE_PORT: "9000"
    ports:
      - "8888:8888"  # http
      - "8887:8887"  # grpc
    healthcheck:
      test: [ "CMD", "wget", "-q", "-S", "-O", "-", "http://localhost:8888/apis/v1beta1/healthz" ]
      interval: 5s
      timeout: 2s
      retries: 10
```


We may need to add further further settings and/or services to make this work.

This is not working yet
```
kfp-api_1    | F0510 23:17:34.698074       6 tekton.go:56] Failed to create TektonClient. Error: Failed to initialize the RestConfig: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
mysql_1      | 2021-05-10T23:17:34.704388Z 7 [Note] Aborted connection 7 to db: 'mlpipeline' user: 'root' host: '172.20.0.5' (Got an error reading communication packets)
kfp-api_1 exited with code 255

```