### PR TITLE
(Work in Progress) Add expandable sidebar items

### DIFF
--- a/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
@@ -67,7 +67,7 @@ function SidebarList() {
                   key={type}
                   icon={(iconMap as any)[type]}
                   name={type === 'inferenceservices' ? 'KFServices' : capitalize(type)}
-                  active={type === active}
+                  active={active}
                 />
               )
             }
@@ -76,7 +76,7 @@ function SidebarList() {
               <SidebarListItem 
                 icon="code"
                 name="Workspace"
-                active={'Workspace' === active}
+                active={active}
               />
             }
           </ul>

--- a/dashboard/origin-mlx/src/components/Sidebar/SidebarListItem.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/SidebarListItem.tsx
@@ -17,36 +17,86 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '@material-ui/core/Icon';
 
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+
 interface SidebarListItemProps {
   name: string;
   icon: string;
-  active: boolean;
+  active: string;
+}
+
+interface ExpandableItemProps {
+  title: string;
+  link: string;
+  icon: string;
+  active: string;
+  items: {
+    name: string;
+    link: string;
+    icon: string;
+  }[]
 }
 
 const SidebarListItem: React.FunctionComponent<SidebarListItemProps> = (props) => {
   const { active: isActive } = props
   var link = props.name.toLocaleLowerCase();
 
+  const pipelinesExpandable: ExpandableItemProps = {
+    title: "Pipelines",
+    link: "pipelines",
+    icon:"device_hub", 
+    active: props.active,
+    items: [
+      {name: "Pipelines", link:"/pipelines", icon:"device_hub"},
+      {name: "Components", link:"/components", icon:"developer_boards"}
+    ]
+  };
+
+  const modelsExpandable: ExpandableItemProps = {
+    title: "Models",
+    link: "models",
+    icon:"layers", 
+    active: props.active,
+    items: [
+      {name: "Registered Models", link:"/models", icon:"layers"},
+      {name: "Deployed Models", link:"/inferenceservices", icon:"layers"}
+    ]
+  };
+
   if (props.name === 'Pipelines') {
     link = 'pipelines'
-  }
-  else if (props.name === "Datasets") {
-    link = 'datasets'
+    return (
+      ExpandableItem(pipelinesExpandable)
+    )
+
   }
   else if (props.name === 'Components') {
     link = 'components'
+    return (
+      <></>
+    );
   }
   else if (props.name === 'Models') {
     link = 'models'
+    return (
+      ExpandableItem(modelsExpandable)
+    )
+  }
+  else if (props.name === 'KFServices') {
+    link = 'inferenceservices'
+    return (
+      <></>
+    );
+  }
+  else if (props.name === "Datasets") {
+    link = 'datasets'
   }
   else if (props.name === 'Notebooks') {
     link = 'notebooks'
   }
   else if (props.name === 'Operators') {
     link = 'operators'
-  }
-  else if (props.name === 'KFServices') {
-    link = 'inferenceservices'
   }
   else if (props.name === 'Workspace') {
     link = 'workspace'
@@ -58,7 +108,7 @@ const SidebarListItem: React.FunctionComponent<SidebarListItemProps> = (props) =
   return (
     <li className="sidebar-list-wrap">
       <Link to={`/${link}`}>
-        <h3 className={`sidebar-list-item ${isActive ? 'active' : 'not-active'}`}>
+        <h3 className={`sidebar-list-item ${isActive === link ? 'active' : 'not-active'}`}>
           <Icon className="sidebar-icon">{props.icon}</Icon>
           {props.name}
         </h3>
@@ -66,5 +116,66 @@ const SidebarListItem: React.FunctionComponent<SidebarListItemProps> = (props) =
     </li>
   );
 };
+
+function ExpandableItem(props: ExpandableItemProps) {
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  function handleClick(event: any) {
+    if (anchorEl !== event.currentTarget) {
+      setAnchorEl(event.currentTarget);
+    }
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  // Prevents using the <Link> route while still using the same styling
+  function cancelClick(event: any) {
+    event.preventDefault();
+  }
+
+  return (
+    <li className="sidebar-list-wrap">
+      <div
+        aria-owns={anchorEl ? "simple-menu" : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+      >
+        <Link to={`/static`} onClick={cancelClick}>
+          <h3 className={`sidebar-list-item ${props.active === props.link ? 'active' : 'not-active'}`}>
+            <Icon className="sidebar-icon">{props.icon}</Icon>
+            {props.title}
+          </h3>
+        </Link>
+      </div>
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        MenuListProps={{ onMouseLeave: handleClose }}
+      >
+        {
+          props.items.map((item) => {
+            return (
+              <MenuItem 
+                className={`expandable-list-menu ${'/'+props.active === item.link ? 'active' : 'not-active'}`} 
+                onClick={handleClose}
+              >
+                <Link className={"inherit-color"} to={item.link}>
+                  <h3 className={"inherit-color"} /*className={`expandable-list-item ${'/'+props.active === item.link ? 'active' : 'not-active'}`}*/>
+                    <Icon className="sidebar-icon">{item.icon}</Icon>
+                    {item.name}
+                  </h3>
+                </Link>
+              </MenuItem>
+            )
+          })
+        }
+      </Menu>
+    </li>
+  )
+}
 
 export default SidebarListItem;

--- a/dashboard/origin-mlx/src/styles/Sidebar.css
+++ b/dashboard/origin-mlx/src/styles/Sidebar.css
@@ -17,9 +17,33 @@ a {
   text-decoration: none;
 }
 
-.sidebar-list-item.not-active:hover,
-.sidebar-list-item.not-active:hover {
+.inherit-color {
+  color: inherit !important;
+}
+
+.expandable-list-menu {
   color: #666 !important;
+  background-color: #fff !important;
+}
+
+.expandable-list-menu.not-active {
+  background-color: #fff;
+}
+
+.expandable-list-menu:hover {
+  color: #444 !important;
+  background-color: #ddd !important;
+}
+
+.expandable-list-item.header {
+  margin-left: 0;
+  display: block;
+  text-align: center;
+  width: 100%;
+}
+
+.expandable-list-menu.active {
+  color: #1ccdc7 !important;
 }
 
 ul {
@@ -41,6 +65,11 @@ ul {
   margin: 0 auto 0 auto;
 }
 
+.sidebar-list-wrap {
+  text-align: center;
+  width: 100%;
+}
+
 .sidebar-list-item.header {
   margin-left: 0;
   display: block;
@@ -48,9 +77,9 @@ ul {
   width: 100%;
 }
 
-.sidebar-list-wrap {
-  text-align: center;
-  width: 100%;
+.sidebar-list-item.not-active:hover,
+.sidebar-list-item.not-active:hover {
+  color: #666 !important;
 }
 
 .sidebar-list-item {
@@ -66,10 +95,6 @@ ul {
 .sidebar-list-item.active,
 .sidebar-list-item:active {
   color: #fff !important;
-}
-
-.sidebar-list-item.not-active {
-  color: #888 !important;
 }
 
 .sidebar-list-item.not-active {


### PR DESCRIPTION
Add expandable sidebar items which can be clicked on to reveal more options. An example of when the `Model` sidebar item is clicked is shown below.

<img width="1063" alt="Screen Shot 2021-05-13 at 2 48 05 PM" src="https://user-images.githubusercontent.com/32145094/118307133-21838800-b49f-11eb-8f5e-66824953e661.png">
<img width="1061" alt="Screen Shot 2021-05-13 at 2 47 53 PM" src="https://user-images.githubusercontent.com/32145094/118307156-2811ff80-b49f-11eb-88d8-81e5bb0e5d79.png">
