### PR TITLE
Add CII Best Practices Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.com/machine-learning-exchange/mlx.svg?branch=main)](https://travis-ci.com/machine-learning-exchange/mlx)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4862/badge)](https://bestpractices.coreinfrastructure.org/projects/4862)
 
 # Machine Learning Exchange (MLX)
 


### PR DESCRIPTION
[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4862/badge)](https://bestpractices.coreinfrastructure.org/projects/4862)

We are currently at 85% passing for the [Linux Foundation 
Core Infrastructure Initiative (CII) Best Practices](https://bestpractices.coreinfrastructure.org/en) [badge](https://bestpractices.coreinfrastructure.org/en/projects/4862).

Outstanding "best practices" like linting, static code analysis,
extended testing, etc are still being implemented.

The goal is for this badge to look like this one for Kubernetes:

[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569)

