### PR TITLE
Verify plain links, include bootstrapper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ git commit -s
 ```
 
 ## Communication
-**FIXME** Please feel free to connect with us on our [Slack channel](link).
+**FIXME** Please feel free to connect with us on our [Slack channel](https://ibm-cloudplatform.slack.com/archives/C0216TCKGCU).
 
 ## Setup
 **FIXME** Please add any special setup instructions for your project to help the developer

--- a/dashboard/origin-mlx/README.md
+++ b/dashboard/origin-mlx/README.md
@@ -75,7 +75,8 @@ There are a few environment variables that can be defined that dictate how MLX i
 * REACT_APP_KIALI - The endpoint for Kiali monitoring
 * REACT_APP_GRAFANA - The endpoint for the Grafana service
 * HTTPS - true/false, defines whether HTTPS or HTTP should be used
-* REACT_APP_BASE_PATH - A basepath can be configured that appends to the end of the address (ex. http://<ip address>:<port>/<basepath>)
+* REACT_APP_BASE_PATH - A basepath can be configured that appends to the end of the address (ex. 
+  http://<ip_address>:<port>/<basepath>)
 * REACT_APP_BRAND - The brand name to use on the website
 
 # Project Overview:


### PR DESCRIPTION
Include plain http/https styled links when checking for invalid URLs using [verify_doc_links.py](https://github.com/ckadner/mlx/blob/b6e5f5f13453e5c4c6168b019aec335e4c6bad10/tools/python/verify_doc_links.py#L86-L91)

Also verify the links to the catalog YAML files in the bootstrapper's [catalog_upload.json](https://github.com/machine-learning-exchange/mlx/blob/main/bootstrapper/catalog_upload.json)