### PR TITLE
Add Travis before script to determine whether to build docker images in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
       name: "UI Build"
       env:
         - DIFF_DETECTED_ERR_CODE=169
+        - DOCKERFILE_DIR=dashboard/origin-mlx
       before_script: &0
         # No diff detected:                   terminate job with success i.e. travis_terminate 0
         # Script throws unexpected error:     fail job with error code
@@ -51,6 +52,7 @@ jobs:
     - name: "API Build"
       env:
         - DIFF_DETECTED_ERR_CODE=169
+        - DOCKERFILE_DIR=api/server
       before_script: *0
       script:
         - cd api/server && docker build -t aipipeline/mlx-api:nightly-$TRAVIS_BRANCH . && cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,32 @@ jobs:
   include:
     - stage: test
       name: "UI Build"
+      env:
+        - DIFF_DETECTED_ERR_CODE=169
+      before_script: &0
+        # No diff detected:                   terminate job with success i.e. travis_terminate 0
+        # Script throws unexpected error:     fail job with error code
+        # Diff detected:                      continue/run this job
+        - git remote add upstream https://github.com/machine-learning-exchange/mlx.git
+        - git fetch upstream
+        - ./tools/bash/check_diff.sh ; EXIT_CODE=$?
+        - |
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "No changes detected - skipping job."
+            travis_terminate 0
+          elif [ $EXIT_CODE -ne $DIFF_DETECTED_ERR_CODE ]; then
+            echo "Unexpected error in check_diff.sh - failing job."
+            travis_terminate $EXIT_CODE
+          fi
+        - echo "Changes detected - continue running job"
       script:
         - cd dashboard/origin-mlx && docker build -t aipipeline/mlx-ui:nightly-origin-$TRAVIS_BRANCH . && cd ..
         - docker images
         - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then docker login -u $username -p $password && docker push aipipeline/mlx-ui:nightly-origin-$TRAVIS_BRANCH; fi
     - name: "API Build"
+      env:
+        - DIFF_DETECTED_ERR_CODE=169
+      before_script: *0
       script:
         - cd api/server && docker build -t aipipeline/mlx-api:nightly-$TRAVIS_BRANCH . && cd ../..
         - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
       name: "UI Build"
       env:
         - DIFF_DETECTED_ERR_CODE=169
-        - DOCKERFILE_DIR=dashboard/origin-mlx
+        - DIFF_DIR=dashboard/origin-mlx
       before_script: &0
         # No diff detected:                   terminate job with success i.e. travis_terminate 0
         # Script throws unexpected error:     fail job with error code
@@ -52,7 +52,7 @@ jobs:
     - name: "API Build"
       env:
         - DIFF_DETECTED_ERR_CODE=169
-        - DOCKERFILE_DIR=api/server
+        - DIFF_DIR=api/server
       before_script: *0
       script:
         - cd api/server && docker build -t aipipeline/mlx-api:nightly-$TRAVIS_BRANCH . && cd ../..

--- a/dashboard/origin-mlx/README.md
+++ b/dashboard/origin-mlx/README.md
@@ -33,7 +33,7 @@ REACT_APP_API=<MLX API Endpoint>
 REACT_APP_KFP=<KFP API Endpoint
 npm start
 ```
-* Configure the API endpoints in the settings page of the UI at 
+* Configure the API endpoints in the settings page of the UI at
 ```
 http://localhost:3000/settings
 ```
@@ -66,7 +66,7 @@ Change the Docker image tag in the deployment spec server/mlx-ui.yml from image:
 kubectl delete -f ./dashboard/origin-mlx/mlx-ui.yml
 kubectl apply -f ./dashboard/origin-mlx/mlx-ui.yml
 ```
-  
+
 # Special Configurations
 There are a few environment variables that can be defined that dictate how MLX is deployed
 * REACT_APP_API - The endpoint for the MLX API
@@ -75,7 +75,7 @@ There are a few environment variables that can be defined that dictate how MLX i
 * REACT_APP_KIALI - The endpoint for Kiali monitoring
 * REACT_APP_GRAFANA - The endpoint for the Grafana service
 * HTTPS - true/false, defines whether HTTPS or HTTP should be used
-* REACT_APP_BASE_PATH - A basepath can be configured that appends to the end of the address (ex. 
+* REACT_APP_BASE_PATH - A basepath can be configured that appends to the end of the address (ex.
   http://<ip_address>:<port>/<basepath>)
 * REACT_APP_BRAND - The brand name to use on the website
 

--- a/tools/bash/check_diff.sh
+++ b/tools/bash/check_diff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 kubeflow.org
+# Copyright 2021 IBM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 # origin/master branch. This is done by running a diff on each file between the
 # most recent commit on origin/master and HEAD.
 #
-# Execute from top-level directory i.e. kfp-tekton/
+# Execute from top-level directory i.e. dashboard/
 #
 # If no changes were detected, return exit code 0.
 # If any changes were detected in any of the files, return exit code
@@ -31,9 +31,7 @@ set -ev
 DIFF_DETECTED_ERR_CODE=${DIFF_DETECTED_ERR_CODE:-169}
 DIFF_DIR=${DIFF_DIR:-.}
 
-org="machine-learning-exchange"
-repository="mlx"
-git_url="git://github.com/${org}/${repository}.git"
+git_url="git://github.com/machine-learning-exchange/mlx.git"
 
 latest_commit=$(git ls-remote ${git_url} | grep HEAD | cut -f 1)
 

--- a/tools/bash/check_diff.sh
+++ b/tools/bash/check_diff.sh
@@ -29,7 +29,7 @@
 set -ev
 
 DIFF_DETECTED_ERR_CODE=${DIFF_DETECTED_ERR_CODE:-169}
-DOCKERFILE_DIR=${DOCKERFILE_DIR:-.}
+DIFF_DIR=${DIFF_DIR:-.}
 
 org="machine-learning-exchange"
 repository="mlx"
@@ -39,7 +39,7 @@ latest_commit=$(git ls-remote ${git_url} | grep HEAD | cut -f 1)
 
 echo "Latest upstream commit: ${latest_commit}"
 
-files_to_check=(${DOCKERFILE_DIR})
+files_to_check=(${DIFF_DIR})
 
 for file in ${files_to_check[@]}
 do

--- a/tools/bash/check_diff.sh
+++ b/tools/bash/check_diff.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright 2020 kubeflow.org
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script checks whether any of the files related to the backend docker
+# build (files listed in files_to_check) have been modified from the
+# origin/master branch. This is done by running a diff on each file between the
+# most recent commit on origin/master and HEAD.
+#
+# Execute from top-level directory i.e. kfp-tekton/
+#
+# If no changes were detected, return exit code 0.
+# If any changes were detected in any of the files, return exit code
+# DIFF_DETECTED_ERR_CODE.
+# If runtime error occurs, script should fail and return error code.
+
+set -ev
+
+DIFF_DETECTED_ERR_CODE=${DIFF_DETECTED_ERR_CODE:-169}
+
+pushd backend > /dev/null
+
+org="machine-learning-exchange"
+repository="mlx"
+git_url="git://github.com/${org}/${repository}.git"
+
+latest_commit=$(git ls-remote ${git_url} | grep HEAD | cut -f 1)
+
+echo "Latest upstream commit: ${latest_commit}"
+
+dockerfiles=(`ls Dockerfile*`)
+files_to_check=(${dockerfiles} src)
+
+for file in ${files_to_check[@]}
+do
+    # Make sure to fetch git_url to make sure this commit exists
+    diff_output=$(git diff ${latest_commit} HEAD -- $file)
+    if [[ -n "${diff_output}" ]]
+    then
+        echo "Diff detected in $file"
+        exit $DIFF_DETECTED_ERR_CODE
+    fi
+done
+
+popd > /dev/null
+
+echo "No diffs detected!"
+
+# Should exit with code 0 anyways, but let's explicitly state it here.
+exit 0

--- a/tools/bash/check_diff.sh
+++ b/tools/bash/check_diff.sh
@@ -29,8 +29,7 @@
 set -ev
 
 DIFF_DETECTED_ERR_CODE=${DIFF_DETECTED_ERR_CODE:-169}
-
-pushd backend > /dev/null
+DOCKERFILE_DIR=${DOCKERFILE_DIR:-.}
 
 org="machine-learning-exchange"
 repository="mlx"
@@ -40,8 +39,7 @@ latest_commit=$(git ls-remote ${git_url} | grep HEAD | cut -f 1)
 
 echo "Latest upstream commit: ${latest_commit}"
 
-dockerfiles=(`ls Dockerfile*`)
-files_to_check=(${dockerfiles} src)
+files_to_check=(${DOCKERFILE_DIR})
 
 for file in ${files_to_check[@]}
 do
@@ -53,8 +51,6 @@ do
         exit $DIFF_DETECTED_ERR_CODE
     fi
 done
-
-popd > /dev/null
 
 echo "No diffs detected!"
 


### PR DESCRIPTION
Add Travis before script to determine whether to build docker images in Travis based on github commit diff because docker has a rate limit on all docker image pull including the official node/python images for our CI/CD test.