### PR TITLE
Enable the Pipeline catalog assets in Docker Compose without the KFP API

### DIFF
--- a/api/server/mlx-api.yml
+++ b/api/server/mlx-api.yml
@@ -58,12 +58,12 @@ spec:
       labels:
         service: mlx-api
         environment: dev
-        version: v0.1.25-related-assets
+        version: v0.1.26
     spec:
       serviceAccountName: mlx-api
       containers:
       - name: mlx-api-server
-        image: docker.io/aipipeline/mlx-api:nightly-master
+        image: docker.io/aipipeline/mlx-api:nightly-main
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/api/server/setup.py
+++ b/api/server/setup.py
@@ -17,7 +17,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "mlx-api"
-VERSION = "0.1.25"
+VERSION = "0.1.26"
 
 # To install the library, run the following
 #

--- a/api/server/swagger_server/__init__.py
+++ b/api/server/swagger_server/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERSION = "0.1.26"  # bypass-kfp-in-docker-compose

--- a/api/server/swagger_server/__main__.py
+++ b/api/server/swagger_server/__main__.py
@@ -1,4 +1,6 @@
-# Copyright 2021 IBM Corporation 
+#!/usr/bin/env python3
+
+# Copyright 2021 IBM Corporation
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); 
 # you may not use this file except in compliance with the License. 
@@ -11,15 +13,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-#!/usr/bin/env python3
+
 
 import connexion
+
+from . import VERSION
 
 from flask_cors import CORS
 from swagger_server import encoder
 
 
 def main():
+
+    print(" * MLX API version: %s" % VERSION)
 
     cx_app = connexion.App(__name__, specification_dir='./swagger/')
 

--- a/api/server/swagger_server/controllers_impl/component_service_controller_impl.py
+++ b/api/server/swagger_server/controllers_impl/component_service_controller_impl.py
@@ -364,7 +364,7 @@ def _upload_component_yaml(yaml_file_content: AnyStr, name=None, existing_id=Non
     component_id = existing_id or generate_id(name=name or yaml_dict["name"])
     created_at = datetime.now()
     name = name or yaml_dict["name"]
-    description = yaml_dict["description"].strip()
+    description = (yaml_dict["description"] or "").strip()[:255]
 
     metadata = ApiMetadata(annotations=template_metadata.get("annotations"),
                            labels=template_metadata.get("labels"),

--- a/api/server/swagger_server/data_access/minio_client.py
+++ b/api/server/swagger_server/data_access/minio_client.py
@@ -191,6 +191,17 @@ def get_object_url(bucket_name, prefix, file_extensions: [str], file_name_filter
     return None
 
 
+def delete_object(bucket_name, prefix, file_name):
+    client = _get_minio_client()
+    try:
+        object_name = f"{prefix.rstrip('/')}/{file_name}"
+        client.remove_object(bucket_name, object_name)
+        return True
+    except NoSuchKey as e:
+        print(e.message)
+        return False
+
+
 def delete_objects(bucket_name, prefix):
     client = _get_minio_client()
     try:
@@ -198,7 +209,7 @@ def delete_objects(bucket_name, prefix):
             prefix = prefix[:-2]
 
         objects = client.list_objects(bucket_name, prefix=prefix, recursive=True)
-        object_names = [obj.object_name for obj in objects  if not obj.is_dir]
+        object_names = [obj.object_name for obj in objects if not obj.is_dir]
         maybe_errors = client.remove_objects(bucket_name, object_names)
         actual_errors = [(e.object_name, e.error_code, e.error_message) for e in maybe_errors]
 

--- a/api/server/swagger_server/swagger/swagger.yaml
+++ b/api/server/swagger_server/swagger/swagger.yaml
@@ -15,7 +15,7 @@
 swagger: "2.0"
 info:
   description: "MLX API Extension for Kubeflow Pipelines"
-  version: "0.1.25-related-assets"
+  version: "0.1.26-bypass-kfp-in-docker-compose"
   title: "MLX API"
 basePath: "/apis/v1alpha1"
 schemes:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -15,7 +15,7 @@
 swagger: "2.0"
 
 info:
-  version: "0.1.25-related-assets"
+  version: "0.1.26-bypass-kfp-in-docker-compose"
   title: "MLX API"
   description: "MLX API Extension for Kubeflow Pipelines"
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -1,16 +1,21 @@
 # Running MLX with Docker Compose
 
-This _"quickstart"_ setup uses Docker Compose to bring up the MLX-API server and
-the MLX Dashboard, along with the MySQL database and Minio S3 storage backend.
-In this configuration, the preloaded asset catalog of Components, Datasets, Models
-and Notebooks can be browsed, asset metadata and sample code can be downloaded
-and new assets can be registered. Sample pipeline code can be generated for each
-asset type, their execution on a Kubeflow Pipelines cluster is not enabled however.
+This _"quickstart"_ setup uses  [Docker Compose](https://docs.docker.com/compose/)
+to bring up the MLX API server and the MLX Dashboard, together with the MySQL
+database and Minio S3 storage backend.
+In this configuration, the preloaded asset catalog of Components, Datasets, Models,
+Notebooks and Pipelines can be browsed, asset metadata and sample code can be
+downloaded and new assets can be registered. Sample pipeline code can be generated
+for each asset type, however their execution on a Kubeflow Pipelines (KFP) cluster
+is not enabled.
+In a Kubernetes cluster deployment of MLX, _Pipelines_ are registered using
+the KFP API and metadata storage is managed by KFP. In this Docker Compose setup
+the _Pipelines_ are stored in Minio and MySQL by the MLX API server.
 
 ## Limitations
 
-The _Pipelines_ and _Inference Service_ capabilities are not available with this
-Docker Compose setup. 
+The _Kubeflow Pipelines_ dashboard and _Inference Service_ capabilities are not
+available with this Docker Compose setup.
 
 ## Prerequisites
 

--- a/quickstart/catalog_upload.json
+++ b/quickstart/catalog_upload.json
@@ -1,56 +1,36 @@
 {
   "components": [
     {
-      "name": "Train Spark Model - IBM Cloud",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/spark/train_spark/component.yaml"
-    },
-    {
-      "name": "Serve PyTorch Model - Seldon Core",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/ffdl/serve/component.yaml"
-    },
-    {
-      "name": "Deploy Model - Watson Machine Learning",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/deploy/component.yaml"
-    },
-    {
-      "name": "Echo",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/echo/echo.yaml"
-    },
-    {
-      "name": "Model Robustness Check - PyTorch",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/metrics/robustness_checker/component.yaml"
-    },
-    {
-      "name": "Model Fairness Check - PyTorch",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/metrics/bias_detector/component.yaml"
-    },
-    {
-      "name": "Deploy Model - Kubernetes",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/kubernetes/kube_deployment/component.yaml"
-    },
-    {
-      "name": "Deploy Model - KFServing",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kubeflow/kfserving/component.yaml"
-    },
-    {
-      "name": "Subscribe - Watson OpenScale",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/manage/subscribe/component.yaml"
-    },
-    {
-      "name": "Store model - Watson Machine Learning",
-      "url": "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/ibm-components/watson/store/component.yaml"
-    },
-    {
-      "name": "Jupyter",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/jupyter/component.yaml"
-    },
-    {
       "name": "Generate Dataset Metadata",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/dax-to-dlf/component.yaml"
     },
     {
       "name": "Create Dataset Volume",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/dlf/component.yaml"
+    },
+    {
+      "name": "Create Secret - Kubernetes Cluster",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/create-secret/component.yaml"
+    },
+    {
+      "name": "Echo Sample",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/echo/component.yaml"
+    },
+    {
+      "name": "Kubernetes Model Deploy",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/kube-model-deployment/component.yaml"
+    },
+    {
+      "name": "Create Model Config",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/component-samples/model-config/component.yaml"
+    },
+    {
+      "name": "Model Fairness Check",
+      "url": "https://raw.githubusercontent.com/Trusted-AI/AIF360/master/mlops/kubeflow/bias_detector_pytorch/component.yaml"
+    },
+    {
+      "name": "Adversarial Robustness Evaluation",
+      "url": "https://raw.githubusercontent.com/Trusted-AI/adversarial-robustness-toolbox/main/utils/mlops/kubeflow/robustness_evaluation_fgsm_pytorch/component.yaml"
     }
   ],
   "datasets": [
@@ -127,10 +107,6 @@
   ],
   "notebooks": [
     {
-      "name": "AIF360 Gender Classification",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/aif360-gender.yaml"
-    },
-    {
       "name": "ART detector model",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/art-detector.yaml"
     },
@@ -145,11 +121,20 @@
     {
       "name": "JFK Airport Analysis",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/JFK-airport.yaml"
-    },
-    {
-      "name": "Train and deploy with Watson Machine Learning",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/watson-ml.yaml"
     }
   ],
-  "pipelines": []
+  "pipelines": [
+    {
+      "name": "Parallel Join",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/parallel_join.yaml"
+    },
+    {
+      "name": "Sequential Pipeline",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/sequential.yaml"
+    },
+    {
+      "name": "ResourceOp Basic",
+      "url": "https://github.com/kubeflow/kfp-tekton/blob/master/sdk/python/tests/compiler/testdata/resourceop_basic.yaml"
+    }
+  ]
 }

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - data-mysql:/var/lib/mysql
 
   mlx-api:
-    image: mlexchange/mlx-api:0.1.25
+    image: mlexchange/mlx-api:0.1.26
     ports:
       - "8080:8080"
     environment:

--- a/quickstart/init_catalog.sh
+++ b/quickstart/init_catalog.sh
@@ -16,13 +16,10 @@ curl -X GET -H 'Accept: application/json' -s "${MLX_API_URL}/health_check?check_
 curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d @catalog_upload.json -s "${MLX_API_URL}/catalog" | grep "total_"
 
 # mark all the catalog assets as approved and featured
-for asset_type in components datasets models notebooks; do
+for asset_type in components datasets models notebooks pipelines; do
   curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/publish_approved"
   curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '["*"]' -s "${MLX_API_URL}/$asset_type/featured"
 done
-
-# disable the Pipelines page, since we don't have a KFP cluster
-curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Pipelines": false}' -s "${MLX_API_URL}/settings" -o /dev/null --show-error
 
 # disable the Inference Services page, since we don't have a KFP cluster
 curl -X PUT -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"Inference Services": false}' -s "${MLX_API_URL}/settings" -o /dev/null --show-error


### PR DESCRIPTION
The KFP API cannot run inside a Docker Compose stack (#28). 

As a workaround, if the KFP host is `"UNAVAILABLE"`, the MLX API server 
will store the pipeline metadata in MySQL and the pipeline template in Minio, 
as opposed to relying on the KFP API for that.

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>