### PR TITLE
Update API to kfp==1.5.0, kfp-tekton==0.8.0, add `namespace` to pipeline API

### DIFF
--- a/api/client/README.md
+++ b/api/client/README.md
@@ -53,7 +53,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.ComponentServiceApi()
-body = swagger_client.ApiComponent() # ApiComponent | 
+body = swagger_client.ApiComponent() # ApiComponent
 
 try:
     api_response = api_instance.create_component(body)

--- a/api/client/docs/ApiPipeline.md
+++ b/api/client/docs/ApiPipeline.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **parameters** | [**list[ApiParameter]**](ApiParameter.md) |  | [optional] 
 **status** | **str** | In case any error happens retrieving a pipeline field, only pipeline ID and the error message is returned. Client has the flexibility of choosing how to handle error. This is especially useful during listing call. | [optional] 
 **default_version_id** | **str** | The default version of the pipeline. As of now, the latest version is used as default. (In the future, if desired by customers, we can allow them to set default version.) | [optional] 
+**namespace** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/docs/ApiPipelineExtended.md
+++ b/api/client/docs/ApiPipelineExtended.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **parameters** | [**list[ApiParameter]**](ApiParameter.md) |  | [optional] 
 **status** | **str** | In case any error happens retrieving a pipeline field, only pipeline ID and the error message is returned. Client has the flexibility of choosing how to handle error. This is especially useful during listing call. | [optional] 
 **default_version_id** | **str** | The default version of the pipeline. As of now, the latest version is used as default. (In the future, if desired by customers, we can allow them to set default version.) | [optional] 
+**namespace** | **str** |  | [optional] 
 **annotations** | **dict(str, str)** |  | [optional] 
 **featured** | **bool** |  | [optional] 
 **publish_approved** | **bool** |  | [optional] 

--- a/api/client/docs/ComponentServiceApi.md
+++ b/api/client/docs/ComponentServiceApi.md
@@ -166,7 +166,7 @@ from urllib3.response import HTTPResponse
 
 # create an instance of the API class
 api_instance = swagger_client.ComponentServiceApi()
-component_id = '3diutD-2nDPQ' # str | 
+component_id = '3diutD-2nDPQ' # str
 include_generated_code = True # bool | Include generated run script in download (optional) (default to false)
 tarfile_path = f'download/component_{component_id}.tgz'
 
@@ -186,7 +186,7 @@ except ApiException as e:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **id** | **str**| UUID of component | 
+ **id** | **str**| UUID of component |
  **include_generated_code** | **bool**| Include generated run script in download | [optional] [default to false]
 
 ### Return type

--- a/api/client/docs/ModelServiceApi.md
+++ b/api/client/docs/ModelServiceApi.md
@@ -167,7 +167,7 @@ from urllib3.response import HTTPResponse
 
 # create an instance of the API class
 api_instance = swagger_client.ModelServiceApi()
-model_id = 'max-audio-classifier'  # str | 
+model_id = 'max-audio-classifier'  # str
 include_generated_code = True  # bool | Include generated run scripts in download (optional) (default to false)
 tarfile_path = f'download/{model_id}.tgz'
 

--- a/api/client/docs/NotebookServiceApi.md
+++ b/api/client/docs/NotebookServiceApi.md
@@ -167,7 +167,7 @@ from urllib3.response import HTTPResponse
 
 # create an instance of the API class
 api_instance = swagger_client.NotebookServiceApi()
-notebook_id = 'ye-23fg0-2ic8' # str | 
+notebook_id = 'ye-23fg0-2ic8' # str
 include_generated_code = True # bool | Include generated run script in download (optional) (default to false)
 tarfile_path = f'download/notebook_{notebook_id}.tgz'
 

--- a/api/client/swagger_client/models/api_pipeline.py
+++ b/api/client/swagger_client/models/api_pipeline.py
@@ -52,7 +52,8 @@ class ApiPipeline(object):
         'description': 'str',
         'parameters': 'list[ApiParameter]',
         'status': 'str',
-        'default_version_id': 'str'
+        'default_version_id': 'str',
+        'namespace': 'str'
     }
 
     attribute_map = {
@@ -62,10 +63,11 @@ class ApiPipeline(object):
         'description': 'description',
         'parameters': 'parameters',
         'status': 'status',
-        'default_version_id': 'default_version_id'
+        'default_version_id': 'default_version_id',
+        'namespace': 'namespace'
     }
 
-    def __init__(self, id=None, created_at=None, name=None, description=None, parameters=None, status=None, default_version_id=None):  # noqa: E501
+    def __init__(self, id=None, created_at=None, name=None, description=None, parameters=None, status=None, default_version_id=None, namespace=None):  # noqa: E501
         """ApiPipeline - a model defined in Swagger"""  # noqa: E501
 
         self._id = None
@@ -75,6 +77,7 @@ class ApiPipeline(object):
         self._parameters = None
         self._status = None
         self._default_version_id = None
+        self._namespace = None
         self.discriminator = None
 
         if id is not None:
@@ -91,6 +94,8 @@ class ApiPipeline(object):
             self.status = status
         if default_version_id is not None:
             self.default_version_id = default_version_id
+        if namespace is not None:
+            self.namespace = namespace
 
     @property
     def id(self):
@@ -242,6 +247,27 @@ class ApiPipeline(object):
         """
 
         self._default_version_id = default_version_id
+
+    @property
+    def namespace(self):
+        """Gets the namespace of this ApiPipeline.  # noqa: E501
+
+
+        :return: The namespace of this ApiPipeline.  # noqa: E501
+        :rtype: str
+        """
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, namespace):
+        """Sets the namespace of this ApiPipeline.
+
+
+        :param namespace: The namespace of this ApiPipeline.  # noqa: E501
+        :type: str
+        """
+
+        self._namespace = namespace
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/api/client/swagger_client/models/api_pipeline_extended.py
+++ b/api/client/swagger_client/models/api_pipeline_extended.py
@@ -55,6 +55,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
         'parameters': 'list[ApiParameter]',
         'status': 'str',
         'default_version_id': 'str',
+        'namespace': 'str',
         'annotations': 'dict(str, str)',
         'featured': 'bool',
         'publish_approved': 'bool'
@@ -68,12 +69,13 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
         'parameters': 'parameters',
         'status': 'status',
         'default_version_id': 'default_version_id',
+        'namespace': 'namespace',
         'annotations': 'annotations',
         'featured': 'featured',
         'publish_approved': 'publish_approved'
     }
 
-    def __init__(self, id=None, created_at=None, name=None, description=None, parameters=None, status=None, default_version_id=None, annotations=None, featured=None, publish_approved=None):  # noqa: E501
+    def __init__(self, id=None, created_at=None, name=None, description=None, parameters=None, status=None, default_version_id=None, namespace=None, annotations=None, featured=None, publish_approved=None):  # noqa: E501
         """ApiPipelineExtended - a model defined in Swagger"""  # noqa: E501
 
         self._id = None
@@ -83,6 +85,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
         self._parameters = None
         self._status = None
         self._default_version_id = None
+        self._namespace = None
         self._annotations = None
         self._featured = None
         self._publish_approved = None
@@ -102,6 +105,8 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
             self.status = status
         if default_version_id is not None:
             self.default_version_id = default_version_id
+        if namespace is not None:
+            self.namespace = namespace
         if annotations is not None:
             self.annotations = annotations
         if featured is not None:
@@ -259,6 +264,27 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
     #     """
     #
     #     self._default_version_id = default_version_id
+    #
+    # @property
+    # def namespace(self):
+    #     """Gets the namespace of this ApiPipelineExtended.  # noqa: E501
+    #
+    #
+    #     :return: The namespace of this ApiPipelineExtended.  # noqa: E501
+    #     :rtype: str
+    #     """
+    #     return self._namespace
+    #
+    # @namespace.setter
+    # def namespace(self, namespace):
+    #     """Sets the namespace of this ApiPipelineExtended.
+    #
+    #
+    #     :param namespace: The namespace of this ApiPipelineExtended.  # noqa: E501
+    #     :type: str
+    #     """
+    #
+    #     self._namespace = namespace
     #
     # @property
     # def annotations(self):

--- a/api/generate_code.sh
+++ b/api/generate_code.sh
@@ -19,8 +19,8 @@ REPO_URL="git@github.com:machine-learning-exchange/mlx.git"
 SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
 PROJECT_DIR="${TRAVIS_BUILD_DIR:-$(cd "${SCRIPT_DIR%/api}"; pwd)}"
 TEMP_DIR="${PROJECT_DIR}/temp"
-CLONE_DIR="${TEMP_DIR}/mlx_master_latest"
-VERSION="master"
+CLONE_DIR="${TEMP_DIR}/mlx_main_latest"
+VERSION="main"
 
 
 #mkdir -p "${CLONE_DIR}"
@@ -41,10 +41,10 @@ clone_repo_to_tempdir() {
     cd "${CLONE_DIR}"
     git config core.sparseCheckout true
     echo "api/*"> .git/info/sparse-checkout
-    git checkout master #-- api
+    git checkout main #-- api
     cd - &> /dev/null
   else
-    echo "Get latest commit from master ..."
+    echo "Get latest commit from main ..."
     cd "${CLONE_DIR}"
     git fetch origin # -q
     git -c advice.detachedHead=false checkout "${VERSION}" -f -- api #-q
@@ -83,7 +83,11 @@ revert_undesired_codegen_results() {
   echo "========================================================================"
   cd "${PROJECT_DIR}"
   #git apply --whitespace=nowarn --reverse "${TEMP_DIR}/undesired_codegen_results_$(date +"%Y-%m-%d").patch"
-  git apply --whitespace=nowarn "${TEMP_DIR}/revert_undesired_codegen_results_$(date +"%Y-%m-%d").patch"
+  git apply --reject --whitespace=fix "${TEMP_DIR}/revert_undesired_codegen_results_$(date +"%Y-%m-%d").patch"
+  echo "========================================================================"
+  echo "Files with undesired changes that could not be reverted:"
+  echo "========================================================================"
+  find .  -name "*.rej" -type f
 }
 
 generate_code

--- a/api/server/mlx-api.yml
+++ b/api/server/mlx-api.yml
@@ -58,7 +58,7 @@ spec:
       labels:
         service: mlx-api
         environment: dev
-        version: v0.1.26
+        version: v0.1.27
     spec:
       serviceAccountName: mlx-api
       containers:

--- a/api/server/requirements.txt
+++ b/api/server/requirements.txt
@@ -6,14 +6,17 @@ pip==20.2.4
 
 setuptools>=41.2.0
 
-kfp==1.4.0
-kfp-tekton==0.7.0
-kfp-notebook==0.14.0
-kfserving==0.4.1
+# TODO: remove after upgrading kfp-tekton 0.8.1, which depends on kfp==1.6.2
+kfp-tekton@git+https://github.com/kubeflow/kfp-tekton.git@v0.8.0#egg=kfp-tekton&subdirectory=sdk/python
+# kfp==1.6.2
+# kfp-tekton==0.8.0
+
+kfp-notebook==0.23.0
+kfserving==0.5.1
 
 # force kubernetes version to "decide" version conflict between kfp and kfserving
 # TODO: remove after upgrading to kfp==1.5.x, kf_serving==0.5.x
-kubernetes==11.0.0
+kubernetes<13,>=8.0.0
 
 requests>=2.25.0
 Werkzeug>=1.0.1

--- a/api/server/setup.py
+++ b/api/server/setup.py
@@ -17,7 +17,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "mlx-api"
-VERSION = "0.1.26"
+VERSION = "0.1.27"  # 0.1.27-pipeline-namespace
 
 # To install the library, run the following
 #

--- a/api/server/swagger_server/__init__.py
+++ b/api/server/swagger_server/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.1.26"  # bypass-kfp-in-docker-compose
+VERSION = "0.1.27"  # 0.1.27-pipeline-namespace

--- a/api/server/swagger_server/__main__.py
+++ b/api/server/swagger_server/__main__.py
@@ -17,10 +17,9 @@
 
 import connexion
 
-from . import VERSION
-
 from flask_cors import CORS
 from swagger_server import encoder
+from swagger_server import VERSION
 
 
 def main():

--- a/api/server/swagger_server/controllers_impl/pipeline_service_controller_impl.py
+++ b/api/server/swagger_server/controllers_impl/pipeline_service_controller_impl.py
@@ -401,6 +401,7 @@ def _store_pipeline(yaml_file_content: AnyStr, name=None, description=None):
 
     name = name or template_metadata["name"]
     description = pipeline_spec.get("description", "").strip()
+    namespace = pipeline_spec.get("namespace", "").strip()
     pipeline_id = "-".join([generate_id(length=l) for l in [8, 4, 4, 4, 12]])
     created_at = datetime.now()
 
@@ -412,7 +413,8 @@ def _store_pipeline(yaml_file_content: AnyStr, name=None, description=None):
                                created_at=created_at,
                                name=name,
                                description=description,
-                               parameters=parameters)
+                               parameters=parameters,
+                               namespace=namespace)
 
     uuid = store_data(api_pipeline)
 

--- a/api/server/swagger_server/models/api_pipeline.py
+++ b/api/server/swagger_server/models/api_pipeline.py
@@ -29,7 +29,7 @@ class ApiPipeline(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, id: str=None, created_at: datetime=None, name: str=None, description: str=None, parameters: List[ApiParameter]=None, status: str=None, default_version_id: str=None):  # noqa: E501
+    def __init__(self, id: str=None, created_at: datetime=None, name: str=None, description: str=None, parameters: List[ApiParameter]=None, status: str=None, default_version_id: str=None, namespace: str=None):  # noqa: E501
         """ApiPipeline - a model defined in Swagger
 
         :param id: The id of this ApiPipeline.  # noqa: E501
@@ -46,6 +46,8 @@ class ApiPipeline(Model):
         :type status: str
         :param default_version_id: The default_version_id of this ApiPipeline.  # noqa: E501
         :type default_version_id: str
+        :param namespace: The namespace of this ApiPipeline.  # noqa: E501
+        :type namespace: str
         """
         self.swagger_types = {
             'id': str,
@@ -54,7 +56,8 @@ class ApiPipeline(Model):
             'description': str,
             'parameters': List[ApiParameter],
             'status': str,
-            'default_version_id': str
+            'default_version_id': str,
+            'namespace': str
         }
 
         self.attribute_map = {
@@ -64,7 +67,8 @@ class ApiPipeline(Model):
             'description': 'description',
             'parameters': 'parameters',
             'status': 'status',
-            'default_version_id': 'default_version_id'
+            'default_version_id': 'default_version_id',
+            'namespace': 'namespace'
         }
 
         self._id = id
@@ -74,6 +78,7 @@ class ApiPipeline(Model):
         self._parameters = parameters
         self._status = status
         self._default_version_id = default_version_id
+        self._namespace = namespace
 
     @classmethod
     def from_dict(cls, dikt) -> 'ApiPipeline':
@@ -236,3 +241,24 @@ class ApiPipeline(Model):
         """
 
         self._default_version_id = default_version_id
+
+    @property
+    def namespace(self) -> str:
+        """Gets the namespace of this ApiPipeline.
+
+
+        :return: The namespace of this ApiPipeline.
+        :rtype: str
+        """
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, namespace: str):
+        """Sets the namespace of this ApiPipeline.
+
+
+        :param namespace: The namespace of this ApiPipeline.
+        :type namespace: str
+        """
+
+        self._namespace = namespace

--- a/api/server/swagger_server/models/api_pipeline_extended.py
+++ b/api/server/swagger_server/models/api_pipeline_extended.py
@@ -31,7 +31,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
     Do not edit the class manually.
     """
 
-    def __init__(self, id: str=None, created_at: datetime=None, name: str=None, description: str=None, parameters: List[ApiParameter]=None, status: str=None, default_version_id: str=None, annotations: Dict[str, str]=None, featured: bool=None, publish_approved: bool=None):  # noqa: E501
+    def __init__(self, id: str=None, created_at: datetime=None, name: str=None, description: str=None, parameters: List[ApiParameter]=None, status: str=None, default_version_id: str=None, namespace: str=None, annotations: Dict[str, str]=None, featured: bool=None, publish_approved: bool=None):  # noqa: E501
         """ApiPipelineExtended - a model defined in Swagger
 
         :param id: The id of this ApiPipelineExtended.  # noqa: E501
@@ -48,6 +48,8 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
         :type status: str
         :param default_version_id: The default_version_id of this ApiPipelineExtended.  # noqa: E501
         :type default_version_id: str
+        :param namespace: The namespace of this ApiPipelineExtended.  # noqa: E501
+        :type namespace: str
         :param annotations: The annotations of this ApiPipelineExtended.  # noqa: E501
         :type annotations: Dict[str, str]
         :param featured: The featured of this ApiPipelineExtended.  # noqa: E501
@@ -63,6 +65,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
             'parameters': List[ApiParameter],
             'status': str,
             'default_version_id': str,
+            'namespace': str,
             'annotations': Dict[str, str],
             'featured': bool,
             'publish_approved': bool
@@ -76,6 +79,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
             'parameters': 'parameters',
             'status': 'status',
             'default_version_id': 'default_version_id',
+            'namespace': 'namespace',
             'annotations': 'annotations',
             'featured': 'featured',
             'publish_approved': 'publish_approved'
@@ -88,6 +92,7 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
         self._parameters = parameters
         self._status = status
         self._default_version_id = default_version_id
+        self._namespace = namespace
         self._annotations = annotations
         self._featured = featured
         self._publish_approved = publish_approved
@@ -253,6 +258,27 @@ class ApiPipelineExtended(ApiPipeline, ApiPipelineExtension):
     #     """
     #
     #     self._default_version_id = default_version_id
+    #
+    # @property
+    # def namespace(self) -> str:
+    #     """Gets the namespace of this ApiPipelineExtended.
+    #
+    #
+    #     :return: The namespace of this ApiPipelineExtended.
+    #     :rtype: str
+    #     """
+    #     return self._namespace
+    #
+    # @namespace.setter
+    # def namespace(self, namespace: str):
+    #     """Sets the namespace of this ApiPipelineExtended.
+    #
+    #
+    #     :param namespace: The namespace of this ApiPipelineExtended.
+    #     :type namespace: str
+    #     """
+    #
+    #     self._namespace = namespace
     #
     # @property
     # def annotations(self) -> Dict[str, str]:

--- a/api/server/swagger_server/swagger/swagger.yaml
+++ b/api/server/swagger_server/swagger/swagger.yaml
@@ -15,7 +15,7 @@
 swagger: "2.0"
 info:
   description: "MLX API Extension for Kubeflow Pipelines"
-  version: "0.1.26-bypass-kfp-in-docker-compose"
+  version: "0.1.27"  # 0.1.27-pipeline-namespace
   title: "MLX API"
 basePath: "/apis/v1alpha1"
 schemes:
@@ -2910,6 +2910,8 @@ definitions:
           \ is used as default. (In the future, if desired by customers, we can allow\
           \ them to set default version.)"
         readOnly: true
+      namespace:
+        type: "string"
     example:
       name: "name"
       created_at: "2000-01-23T04:56:07.000+00:00"

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -15,7 +15,7 @@
 swagger: "2.0"
 
 info:
-  version: "0.1.26-bypass-kfp-in-docker-compose"
+  version: "0.1.27-pipeline-namespace"
   title: "MLX API"
   description: "MLX API Extension for Kubeflow Pipelines"
 
@@ -2709,6 +2709,8 @@ definitions:
           \ version is used as default. (In the future, if desired by customers, we\
           \ can allow them to set default version.)"
         readOnly: true
+      namespace:
+        type: "string"
     example:
       name: "name"
       created_at: "2000-01-23T04:56:07.000+00:00"

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - data-mysql:/var/lib/mysql
 
   mlx-api:
-    image: mlexchange/mlx-api:0.1.26
+    image: mlexchange/mlx-api:0.1.27
     ports:
       - "8080:8080"
     environment:

--- a/quickstart/init_db.sql
+++ b/quickstart/init_db.sql
@@ -15,8 +15,9 @@ CREATE TABLE IF NOT EXISTS `pipelines` (
   `Parameters` longtext NOT NULL,
   `Status` varchar(255) NOT NULL,
   `DefaultVersionId` varchar(255) DEFAULT NULL,
+  `Namespace` varchar(63) DEFAULT '',
   PRIMARY KEY (`UUID`),
-  UNIQUE KEY `name_index` (`Name`)
+  UNIQUE KEY `name_namespace_index` (`Name`,`Namespace`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `pipeline_versions` (
@@ -38,5 +39,5 @@ CREATE TABLE IF NOT EXISTS `pipeline_versions` (
 -- don't populate tables since we won't have the accompanying "template" YAML stored on Minio
 --
 
--- INSERT INTO `pipelines` VALUES ('c616527f-1f3c-4f0c-aada-35fa2cc4feb3',1619547888,'[Demo] flip-coin','[source code](https://github.com/kubeflow/kfp-tekton/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.','[]','READY','c616527f-1f3c-4f0c-aada-35fa2cc4feb3');
+-- INSERT INTO `pipelines` VALUES ('c616527f-1f3c-4f0c-aada-35fa2cc4feb3',1619547888,'[Demo] flip-coin','[source code](https://github.com/kubeflow/kfp-tekton/tree/master/samples/flip-coin) A conditional pipeline to flip coins based on a random number generator.','[]','READY','c616527f-1f3c-4f0c-aada-35fa2cc4feb3','');
 -- INSERT INTO `pipeline_versions` VALUES ('c616527f-1f3c-4f0c-aada-35fa2cc4feb3',1619547888,'[Demo] flip-coin','[]','c616527f-1f3c-4f0c-aada-35fa2cc4feb3','READY','');


### PR DESCRIPTION
### Work completed in this PR:

* [x] update API Python requirements (temporarily build kfp and kfp-tekton from Git)
* [x] update API database schema with additional `namespace` field
* [x] update Quickstart with docker-compose

### Outstanding work:

The following are captured in issue #76

* [ ] **upload** pipelines only by authenticated user:
  * [ ] without providing a `namespace` makes the pipeline public (**DEFAULT ?**)
  * [ ] with his/her `namespace` makes the pipeline private
* [ ] **launching** pipelines requires user's `namespace` (implicitly provided by UI, explicitly accepted by API)
* [ ] **listing** pipelines:
  * [ ] by `anonymous` user shows only public pipelines
  * [ ] by authenticated user shows his/her private pipelines and all public pipelines (API takes `namespace` parameter?)
* [ ] verify API deployment in cluster with Kubeflow Pipelines 1.5.0
* [ ] TODO: @Tomcli add MySQL policy back into demo cluster

Resolves #44, #50