### PR TITLE
Update readme details for Kubeflow 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Additionally it provides:
 
 ## 1. Prerequisites
 
-* An existing Kubernetes cluster. Version 1.16+
+* An existing Kubernetes cluster. Version 1.17+
 * The minimum capacity requirement for MLX is 8 vCPUs and 16GB RAM
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
@@ -43,7 +43,7 @@ For Deployment, we are going to use an Operator based on [Kubeflow Operator](htt
 
 ## 3. Access the MLX UI
 
-1. By default the MLX UI is available at <public-ip-of-node>:31380/os
+1. By default the MLX UI is available at <public-ip-of-node>:30380/os
 
 To find the public ip of a node of your cluster
 


### PR DESCRIPTION
For Kubeflow 1.3, the minimum k8s version is 1.17 and the default nodeport are exposed to 30380.