### PR TITLE
Remove swagger-codegen-cli jar file

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,6 @@
 
 An extension to the Kubeflow Pipeline API for Components and Models
 
-
 # Quickstart    
 
 ## Deploy to Kubernetes
@@ -22,9 +21,25 @@ An extension to the Kubeflow Pipeline API for Components and Models
 
 # Development Setup
 
-## Swagger CLI
+## Swagger Codegen 2.4.
 
-    npm install -g swagger-cli
+We are using `swagger-codegen` version `2.4.x` to generate our API as `swagger-codegen`
+version `3.0.x` no longer supports `python` (server) any longer.
+
+Below are the instructions for installing 
+[`swagger-codegen@2`](https://formulae.brew.sh/formula-linux/swagger-codegen@2) using
+[Homebrew](https://docs.brew.sh/Installation) on Mac OS. 
+
+For installation on other platforms, go to 
+[`swagger-api/swagger-codegen`](https://github.com/swagger-api/swagger-codegen#swagger-codegen-2x-master-branch)
+on GitHub.
+
+**Note:** `swagger-codegen` `3.x` does not support the Python (server) anymore, 
+so we need to downgrade to version `2.x` (`@2`):
+
+    brew search swagger-codegen@
+    brew install swagger-codegen@2
+    brew link --force swagger-codegen@2
 
 ## Python Virtual Environment for Development
 
@@ -62,16 +77,3 @@ or:
 
     kubectl delete -f ./server/mlx-api.yml
     kubectl apply -f ./server/mlx-api.yml
-
-## Latest Swagger Codegen
-
-  We are using Swagger `2.4.8` for our API due to some inconsistency with the latest Swagger on Mac.
-  Below are the instructions for pulling the latest Swagger using brew, but we will not be using it
-  for our general development.
-
-  **Note:** `swagger-codegen` `3.0.x` does not support Python (server) anymore, 
-  so we need to downgrade to version 2.x:
-
-    brew search swagger-codegen@
-    brew install swagger-codegen@2
-    brew link --force swagger-codegen@2

--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -20,7 +20,7 @@ UTIL_FILE="${SCRIPT_DIR}/server/swagger_server/util.py"
 
 cd "$SCRIPT_DIR"
 
-swagger-cli validate swagger/swagger.yaml || exit 1
+swagger-codegen validate -i swagger/swagger.yaml || exit 1
 
 echo "Generating Python client:"
 swagger-codegen generate -i swagger/swagger.yaml -l python       -o client 2>&1 | grep -v -E "writing file|/test/" | sed "s|${SCRIPT_DIR}|.|g"


### PR DESCRIPTION
The `swagger-codegen` CLI can be readily installed from external sources and need not be part of this repository.

> The JAR file `/api/swagger-codegen-cli-2.4.8.jar` appears to contain a large number of Java dependencies in binary form (approx. 7000 .class Java binary files). We recommend that LF projects should _not_ distribute binary files as part of their source code repositories. There are several reasons for this, including because it is harder for users of the source code repos to know about the provenance or contents of the binary files. In the presence of copyleft licenses these binaries might require sharing the corresponding source code.

> It is strongly recommended this JAR file be removed from the source code repo, and instead (if necessary) configuring the build system to retrieve it from an upstream location at build time / install time, as applicable. Or, alternatively, adjusting the documentation to instruct users where they can obtain these dependencies themselves, rather than distributing the binaries

Furthermore, the `swagger-cli` is not required for code generation. Only the `swagger-codegen` is required.
## Swagger Codegen 2.4.

We are using `swagger-codegen` version `2.4.x` to generate our API as `swagger-codegen`
version `3.0.x` no longer supports `python` (server) any longer.

Below are the instructions for installing the latest [`swagger-codegen@2`](https://formulae.brew.sh/formula-linux/swagger-codegen@2) using [Homebrew](https://docs.brew.sh/Installation). For installation on other platforms, go to [`swagger-api/swagger-codegen`](https://github.com/swagger-api/swagger-codegen#swagger-codegen-2x-master-branch) on GitHub.

**Note:** `swagger-codegen` `3.x` does not support the Python (server) anymore, so we need to downgrade to version `2.x` (`@2`):

    brew search swagger-codegen@
    brew install swagger-codegen@2
    brew link --force swagger-codegen@2

---

Resolves #70

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>