### PR TITLE
[mlx-ui] add session-validation

### DIFF
--- a/dashboard/origin-mlx/server/users.ts
+++ b/dashboard/origin-mlx/server/users.ts
@@ -25,6 +25,7 @@ export type Users = {
  */
 type UserInfo = {
     password: string; // password
+    email: string;    // email
     roles: string[]; // roles for the user
 };
 
@@ -35,6 +36,6 @@ export function loadUsers(): Users {
         return require(DEFAULT_USER_CONFIG);
     }
     // return default settings if config file doesn't exist
-    return {"admin": {"password": "passw0rd", "roles": ["admin"]}};
+    return {"admin": {"password": "passw0rd", "email": "mlx@ibm.com", "roles": ["admin"]}};
 }
 

--- a/dashboard/origin-mlx/src/App.tsx
+++ b/dashboard/origin-mlx/src/App.tsx
@@ -438,7 +438,7 @@ function App() {
                     render={({match, location}) =>
                       <IframePage
                         title="KFP Experiments"
-                        path={KFP + "/pipeline/#/experiments" + window.location.pathname.substring(window.location.pathname.indexOf("/experiments")+12)}
+                        path={KFP + "/_/pipeline/?ns=mlx#/experiments" + window.location.pathname.substring(window.location.pathname.indexOf("/experiments")+12)}
                         storageKey="experiments-iframe"
                       />
                     }

--- a/manifests/base/mlx-profile.yaml
+++ b/manifests/base/mlx-profile.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - mlx-api.yaml
-  - mlx-ui.yaml
-  - mlx-profile.yaml
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: mlx
+  namespace: kubeflow
+spec:
+  owner:
+    kind: User
+    name: mlx@ibm.com

--- a/manifests/base/mlx-ui.yaml
+++ b/manifests/base/mlx-ui.yaml
@@ -26,7 +26,7 @@ type: Opaque
 stringData:
   admin.json: |
     {
-      "admin": { "password": "passw0rd", "roles": ["admin"] }
+      "admin": { "password": "passw0rd", "email": "mlx@ibm.com", "roles": ["admin"] }
     }
   session: "machine learning exchange"
 ---
@@ -62,6 +62,8 @@ spec:
           value: "true"
         - name: REACT_APP_BASE_PATH
           value: /os
+        - name: KUBEFLOW_USERID_HEADER
+          value: kubeflow-userid
         - name: SESSION_SECRET
           valueFrom:
             secretKeyRef:

--- a/manifests/istio-auth/istio-configmap.yaml
+++ b/manifests/istio-auth/istio-configmap.yaml
@@ -1,0 +1,50 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: kustomize.config.k8s.io/v1beta1
+#
+# Since this modify the istio configmap, need to restart istiod with the
+# following command:
+#     kubectl rollout restart deployment/istiod -n istio-system
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio
+  namespace: istio-system
+data:
+  mesh: |-
+    accessLogFile: /dev/stdout
+    defaultConfig:
+      discoveryAddress: istiod.istio-system.svc:15012
+      proxyMetadata: {}
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+    enablePrometheusMerge: true
+    rootNamespace: istio-system
+    trustDomain: cluster.local
+    extensionProviders:
+    - name: "mlx-authz-http"
+      envoyExtAuthzHttp:
+        service: "mlx-ui.kubeflow.svc.cluster.local"
+        port: "80"
+        pathPrefix: "/session-validation"
+        includeHeadersInCheck: ["cookie", "x-ext-authz"]
+        headersToUpstreamOnAllow: ["kubeflow-userid"]
+        headersToDownstreamOnDeny: ["content-type", "set-cookie"]
+  meshNetworks: 'networks: {}'

--- a/manifests/istio-auth/mlx-ext-authz.yaml
+++ b/manifests/istio-auth/mlx-ext-authz.yaml
@@ -1,4 +1,3 @@
-
 # Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,10 +10,24 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - mlx-api.yaml
-  - mlx-ui.yaml
-  - mlx-profile.yaml
+# limitations under the License.apiVersion: rbac.istio.io/v1alpha1
+#
+# Need to remove the "authn-filter" envoyfilter and replace it with
+# this mlx-ext-authz
+#
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: mlx-ext-authz
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  action: CUSTOM
+  provider:
+    name: "mlx-authz-http"
+  rules:
+  - to:
+    - operation:
+        notPaths: ["/os*"]


### PR DESCRIPTION
- Register mlx-ui as an external authorization provider in istio
- Add session validation API in mlx-ui to behave as an authorization
  provider
- Add a profile to represent admin user: mlx@ibm.com
- Add email as one of user's information

Signed-off-by: Yihong Wang <yh.wang@ibm.com>