### PR TITLE
Quickstart should use nightly images for API and UI

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - data-mysql:/var/lib/mysql
 
   mlx-api:
-    image: mlexchange/mlx-api:0.1.27
+    image: mlexchange/mlx-api:nightly-main
     ports:
       - "8080:8080"
     environment:
@@ -59,7 +59,7 @@ services:
       ML_PIPELINE_UI_SERVICE_PORT: "UNAVAILABLE"
 
   mlx-ui:
-    image: mlexchange/mlx-ui:2021.05.06
+    image: mlexchange/mlx-ui:nightly-origin-main
     ports:
       - "80:3000"
     environment:


### PR DESCRIPTION
Quickstart with Docker Compose was using stale images for API and UI as reported in #85

Resolves #85 

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>