### PR TITLE
[mlx-ui] Add an ENV var to disable login

### DIFF
--- a/dashboard/origin-mlx/README.md
+++ b/dashboard/origin-mlx/README.md
@@ -78,6 +78,7 @@ There are a few environment variables that can be defined that dictate how MLX i
 * REACT_APP_BASE_PATH - A basepath can be configured that appends to the end of the address (ex.
   http://<ip_address>:<port>/<basepath>)
 * REACT_APP_BRAND - The brand name to use on the website
+* REACT_APP_DISABLE_LOGIN - A switch to turn off login mechanism
 
 # Project Overview:
 

--- a/dashboard/origin-mlx/package.json
+++ b/dashboard/origin-mlx/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start-dev": "HTTPS=false REACT_APP_BRAND=<BRAND> REACT_APP_API=<MLX API> REACT_APP_KFP=<KFP> REACT_APP_NBVIEWER_API=<Notebook Viewer API> react-scripts start",
+    "start-dev": "HTTPS=false REACT_APP_BRAND=<BRAND> REACT_APP_API=<MLX API> REACT_APP_KFP=<KFP> REACT_APP_NBVIEWER_API=<Notebook Viewer API> REACT_APP_DISABLE_LOGIN=<true|false> react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/dashboard/origin-mlx/server/users.ts
+++ b/dashboard/origin-mlx/server/users.ts
@@ -30,12 +30,13 @@ type UserInfo = {
 };
 
 const DEFAULT_USER_CONFIG = '/workspace/models/admin.json';
+export const DEFAULT_ADMIN_EMAIL = 'mlx@ibm.com';
 
 export function loadUsers(): Users {
     if (existsSync(DEFAULT_USER_CONFIG)) {
         return require(DEFAULT_USER_CONFIG);
     }
     // return default settings if config file doesn't exist
-    return {"admin": {"password": "passw0rd", "email": "mlx@ibm.com", "roles": ["admin"]}};
+    return {"admin": {"password": "passw0rd", "email": DEFAULT_ADMIN_EMAIL, "roles": ["admin"]}};
 }
 

--- a/dashboard/origin-mlx/src/lib/util.ts
+++ b/dashboard/origin-mlx/src/lib/util.ts
@@ -15,6 +15,8 @@
 */ 
 import Cookies from 'js-cookie';
 
+const disableLogin = process.env.REACT_APP_DISABLE_LOGIN === 'true';
+
 type UserInfo = {
   username: string;
   roles: string[];
@@ -22,11 +24,10 @@ type UserInfo = {
 
 const DEFAULT_USERINFO = {
   username: 'user',
-  roles: ['user']
+  roles: [disableLogin ? 'admin' : 'user']
 };
 
 let gUserInfo: UserInfo;
-
 export function getUserInfo(): UserInfo {
   return gUserInfo || (() => {
     const userinfo = Cookies.get('userinfo');

--- a/manifests/base/mlx-ui.yaml
+++ b/manifests/base/mlx-ui.yaml
@@ -62,6 +62,8 @@ spec:
           value: "true"
         - name: REACT_APP_BASE_PATH
           value: /mlx
+        - name: REACT_APP_DISABLE_LOGIN
+          value: "false"
         - name: KUBEFLOW_USERID_HEADER
           value: kubeflow-userid
         - name: SESSION_SECRET


### PR DESCRIPTION
Use an ENV var to control if login mechanism is needed
or not. When the login is off, all requests are treated
as admin.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>