### PR TITLE
Run quickstart as admin

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -64,11 +64,12 @@ services:
       - "80:3000"
     environment:
       REACT_APP_BRAND: "Machine Learning Exchange"
-      REACT_APP_RUN: "true"
+      REACT_APP_RUN: "false"
       REACT_APP_UPLOAD: "true"
       REACT_APP_BASE_PATH: ""
       REACT_APP_API: "${DOCKER_HOST_IP:-localhost}:8080"
       REACT_APP_KFP: ""
+      REACT_APP_DISABLE_LOGIN: "true"
 
   catalog:
     image: curlimages/curl


### PR DESCRIPTION
Disable the MLX-UI login (see #87) for the [**Quickstart** with Docker Compose](https://github.com/machine-learning-exchange/mlx/tree/main/quickstart) in order to enable registration (upload), deletion, and publishing of assets.

@romeokienzler 

Resolves #97

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>