### PR TITLE
[mlx-ui] fix: empty REACT_APP_BASE_PATH env

### DIFF
--- a/dashboard/origin-mlx/server/server.ts
+++ b/dashboard/origin-mlx/server/server.ts
@@ -167,11 +167,12 @@ function initLogin(app: express.Application) {
   app.use(passport.initialize())
   app.use(passport.session())
 
+  const redirectPath = REACT_APP_BASE_PATH.length === 0 ? '/' : REACT_APP_BASE_PATH;
   app.get([REACT_APP_BASE_PATH + '/login'],
     passport.authenticate('basic'),
     (req, res) => {
       res.cookie('userinfo', JSON.stringify(req.user), {maxAge: 86400000});
-      res.redirect(REACT_APP_BASE_PATH);
+      res.redirect(redirectPath);
     }
   );
 }


### PR DESCRIPTION
When using empty value for REACT_APP_BASE_PATH or the env
doesn't exist, the redirect after login fails. Because using empty
value for `Location` header is invalid. Fix it by using `/` in
redirect when REACT_APP_BASE_PATH is empty value.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>