### PR TITLE
Fix status line bug and improve form feedback

### DIFF
--- a/dashboard/origin-mlx/src/pages/KFServingUploadPage.tsx
+++ b/dashboard/origin-mlx/src/pages/KFServingUploadPage.tsx
@@ -43,6 +43,7 @@ function UploadPage(props: RouteComponentProps<MatchProps>) {
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     setFile(e.currentTarget.files[0])
+    setError('')
     const fileReader = new FileReader();
     fileReader.onloadend = () => {
       if (typeof fileReader.result === 'string') {

--- a/dashboard/origin-mlx/src/pages/UploadPage.tsx
+++ b/dashboard/origin-mlx/src/pages/UploadPage.tsx
@@ -63,6 +63,7 @@ function UploadPage(props: RouteComponentProps<MatchProps>) {
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     setFile(e.currentTarget.files[0])
+    setError('')
     setUploadStatus({fullStatus: e.currentTarget.files[0].name, link: ''})
   }
 

--- a/dashboard/origin-mlx/src/styles/Models.css
+++ b/dashboard/origin-mlx/src/styles/Models.css
@@ -517,7 +517,6 @@ div:hover>.upload-button {
   display: flex;
   flex-direction: column;
   min-width: 40%;
-  height: 44%;
   margin-top: 10%;
   background-color: #666 !important;
   color: white;


### PR DESCRIPTION
Resolves: #102

Form was set to a % size of page which caused certain elements to overflow on certain sized browsers. Change form to expand to size of contents. Also add improved feedback for adding more than one asset.