### PR TITLE
[mlx-ui] Use proper namespace in iframe

### DIFF
--- a/dashboard/origin-mlx/src/App.tsx
+++ b/dashboard/origin-mlx/src/App.tsx
@@ -55,6 +55,18 @@ function App() {
   if (!window.location.pathname.substring(0, prefix.length+12).includes(prefix + "/experiments"))
     localStorage.removeItem("experiments-iframe")
 
+  // receive iframe message when iframe is loaded and send correct namespace back.
+  window.addEventListener('message', (event: MessageEvent) => {
+    const { data, origin } = event;
+    switch (data.type) {
+    case 'iframe-connected':
+      const element = document.getElementById("iframe") as HTMLIFrameElement;
+      // TODO: get namespace from user info, use fixed value: mlx for now
+      element.contentWindow.postMessage({type: 'namespace-selected', value: 'mlx'}, origin);
+      break;
+    }
+  });
+
   return (
     <div className="app-wrapper">
       <Store
@@ -438,7 +450,7 @@ function App() {
                     render={({match, location}) =>
                       <IframePage
                         title="KFP Experiments"
-                        path={KFP + "/_/pipeline/?ns=mlx#/experiments" + window.location.pathname.substring(window.location.pathname.indexOf("/experiments")+12)}
+                        path={KFP + "/pipeline/#/experiments" + window.location.pathname.substring(window.location.pathname.indexOf("/experiments")+12)}
                         storageKey="experiments-iframe"
                       />
                     }


### PR DESCRIPTION
Receive message from iframe when iframe is loaded
and send namespace info back to the iframe in order
to display the correct content.

fix: #77 
Signed-off-by: Yihong Wang <yh.wang@ibm.com>