### PR TITLE
Fix model config image for MLX

### DIFF
--- a/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
@@ -37,7 +37,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='tomcli/model-config',
+        image='aipipeline/model-config',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',


### PR DESCRIPTION
The tomcli/model-config image is for running component on openaihub service. The new model config image is rebuilt with the aipipeline/model-config as described in Katalog component.yaml https://github.com/machine-learning-exchange/katalog/blob/main/component-samples/model-config/component.yaml#L21

If we have time to setup a daily CI build for Katalog, we should let it push to mlexchange org using the new bot. 