### PR TITLE
[mlx-api] prepare context.json for kfp.KfpClient

### DIFF
--- a/manifests/base/mlx-api.yaml
+++ b/manifests/base/mlx-api.yaml
@@ -28,6 +28,24 @@ spec:
   selector:
     service: mlx-api
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlx-api-configmap
+  namespace: kubeflow
+data:
+  # for kfp context.json
+  # Note: currently these is only one user profile and mlx namespace.
+  #       use the context which using 'mlx' namespace, to create kfp.KfpClient
+  #       and send proper user headers to ml-pipeline api
+  #       need to find a way to support multi user profile in the future
+  kfp-context: |
+    {
+      "namespace": "mlx",
+      "client_authentication_header_name": "kubeflow-userid",
+      "client_authentication_header_value": "mlx@ibm.com"
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -65,6 +83,10 @@ spec:
           limits:
             cpu: 250m
             memory: 256Mi
+        volumeMounts:
+        - name: context
+          mountPath: "/root/.config/kfp"
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /apis/v1alpha1/health_check?check_database=true&check_object_store=true
@@ -73,6 +95,13 @@ spec:
           timeoutSeconds: 10
           periodSeconds: 60
           failureThreshold: 3
+      volumes:
+      - name: context
+        configMap:
+          name: mlx-api-configmap
+          items:
+          - key: kfp-context
+            path: context.json
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Use the context.json to store the namespace, userid header and
value for kfp.KfpClient. In this way, kfp.KfpClient sends out
userid header when calling ml-pipeline api. It's a temporally
workaround for not able to pass userid header via kfp.KfpClient
directly.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>