### PR TITLE
Add manifest to setup MLX prod multi-user

### DIFF
--- a/dashboard/origin-mlx/package-lock.json
+++ b/dashboard/origin-mlx/package-lock.json
@@ -2117,8 +2117,7 @@
     "@types/js-cookie": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
-      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==",
-      "dev": true
+      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw=="
     },
     "@types/js-yaml": {
       "version": "3.12.6",
@@ -15548,6 +15547,21 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "title-case": {
+      "version": "3.0.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-wdp-npm-virtual/title-case/-/title-case-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftitle-case%2F-%2Ftitle-case-3.0.3.tgz",
+      "integrity": "sha1-vGibRvAuQR8dHh0IH3w97KBImYI=",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/wcp-wdp-npm-virtual/tslib/-/tslib-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.3.0.tgz",
+          "integrity": "sha1-gDuM2rPhK6WBpMpByIObuw2ssJ4="
+        }
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/dashboard/origin-mlx/package.json
+++ b/dashboard/origin-mlx/package.json
@@ -33,6 +33,7 @@
     "reactjs-popup": "^1.5.0",
     "reactstrap": "^8.5.1",
     "styled-components": "^4.3.1",
+    "title-case": "^3.0.3",
     "typescript": "^3.5.2",
     "typestyle": "^2.0.1",
     "yamljs": "^0.3.0"

--- a/docs/install-mlx-on-kubeflow.md
+++ b/docs/install-mlx-on-kubeflow.md
@@ -12,4 +12,21 @@ cd mlx
 kubectl apply -k manifests/istio-auth
 ```
 
-Then access the MLX page using `http://<Kubeflow_Endpoint>/os/`
+Then access the MLX page using `http://<Kubeflow_Endpoint>/mlx/`
+
+
+## Replacing Kubeflow Central Dashboard with MLX Dashboard
+
+To deploy MLX on Kubeflow (With OIDC and Istio Mutual Auth) and replace Kubeflow Central Dashboard with MLX Dashboard, run the following commands:
+
+```shell
+git clone https://github.com/machine-learning-exchange/mlx
+cd mlx
+```
+
+- Deploy MLX on Kubeflow (With OIDC and Istio Mutual Auth)
+```shell
+kubectl apply -k manifests/prod-multi-user
+```
+
+Then access the MLX page using `http://<Kubeflow_Endpoint>/`

--- a/manifests/prod-multi-user/envoy-filter-patch.yaml
+++ b/manifests/prod-multi-user/envoy-filter-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: authn-filter
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: dummygateway

--- a/manifests/prod-multi-user/kubeflow-dashboard-patch.yaml
+++ b/manifests/prod-multi-user/kubeflow-dashboard-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /kubeflow
+    rewrite:
+      uri: /kubeflow
+    route:
+    - destination:
+        host: centraldashboard.kubeflow.svc.cluster.local
+        port:
+          number: 80

--- a/manifests/prod-multi-user/kubeflow-dashboard-patch.yaml
+++ b/manifests/prod-multi-user/kubeflow-dashboard-patch.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: kustomize.config.k8s.io/v1beta1
+
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:

--- a/manifests/prod-multi-user/kustomization.yaml
+++ b/manifests/prod-multi-user/kustomization.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.apiVersion: kustomize.config.k8s.io/v1beta1
+
 kind: Kustomization
 bases:
   - ../istio-auth

--- a/manifests/prod-multi-user/kustomization.yaml
+++ b/manifests/prod-multi-user/kustomization.yaml
@@ -18,6 +18,7 @@ bases:
 resources:
   - kubeflow-dashboard-patch.yaml
   - oidc-patch.yaml
+  - envoy-filter-patch.yaml
 patchesStrategicMerge:
   - mlx-ui-patch.yaml
   - mlx-ext-authz-patch.yaml

--- a/manifests/prod-multi-user/kustomization.yaml
+++ b/manifests/prod-multi-user/kustomization.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../istio-auth
+resources:
+  - kubeflow-dashboard-patch.yaml
+  - oidc-patch.yaml
+patchesStrategicMerge:
+  - mlx-ui-patch.yaml
+  - mlx-ext-authz-patch.yaml

--- a/manifests/prod-multi-user/mlx-ext-authz-patch.yaml
+++ b/manifests/prod-multi-user/mlx-ext-authz-patch.yaml
@@ -1,0 +1,57 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: rbac.istio.io/v1alpha1
+#
+# Need to remove the "authn-filter" envoyfilter and replace it with
+# this mlx-ext-authz
+#
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: mlx-ext-authz
+  namespace: istio-system
+spec:
+  action: CUSTOM
+  provider:
+    name: mlx-authz-http
+  rules:
+  - to:
+    - operation:
+        notPaths:
+        - /
+        - /index*
+        - /login*
+        - /mlx*.png
+        - /static*
+        - /datasets*
+        - /models*
+        - /pipelines*
+        - /components*
+        - /notebooks*
+        - /inferenceservices*
+        - /dashboard_lib.bundle.js*
+        - /apis*
+        - /manifest.json
+        - /mlx-logo-white.png
+        - /favicon.ico
+  - to:
+    - operation:
+        methods:
+        - POST
+        - DELETE
+        - PUT
+        paths:
+        - /apis*
+  selector:
+    matchLabels:
+      istio: ingressgateway

--- a/manifests/prod-multi-user/mlx-ui-patch.yaml
+++ b/manifests/prod-multi-user/mlx-ui-patch.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/prod-multi-user/mlx-ui-patch.yaml
+++ b/manifests/prod-multi-user/mlx-ui-patch.yaml
@@ -1,0 +1,92 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlx-ui
+  namespace: kubeflow
+  labels:
+    service: mlx-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mlx-ui
+  template:
+    metadata:
+      name: mlx-ui
+      labels:
+        service: mlx-ui
+    spec:
+      containers:
+      - name: mlx-ui
+        # You can use your own webapp image below
+        image: mlexchange/mlx-ui:nightly-origin-main
+        imagePullPolicy: Always
+        env:
+        - name: REACT_APP_BRAND
+          value: "Machine Learning eXchange"
+        - name: REACT_APP_RUN
+          value: "true"
+        - name: REACT_APP_UPLOAD
+          value: "true"
+        - name: REACT_APP_BASE_PATH
+          value: ""
+        - name: REACT_APP_DISABLE_LOGIN
+          value: "false"
+        - name: KUBEFLOW_USERID_HEADER
+          value: kubeflow-userid
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: mlx-dashboard-admin
+              key: session
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - mountPath: /workspace/models
+          name: dashboard-admin
+          readOnly: true
+          # When deploying MLX on OpenShift, readOnly SCC may be required for mlx-ui.
+      volumes:
+      - name: dashboard-admin
+        secret:
+          items:
+          - key: admin.json
+            path: admin.json
+          secretName: mlx-dashboard-admin
+      serviceAccountName: mlx-ui
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: mlx-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: mlx-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80
+    timeout: 300s

--- a/manifests/prod-multi-user/oidc-patch.yaml
+++ b/manifests/prod-multi-user/oidc-patch.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.apiVersion: kustomize.config.k8s.io/v1beta1
+
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/manifests/prod-multi-user/oidc-patch.yaml
+++ b/manifests/prod-multi-user/oidc-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authservice
+  namespace: istio-system
+spec:
+  gateways:
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        # Dummy path to avoid mlx-ui login redirect path
+        prefix: /oidc/login
+    route:
+    - destination:
+        host: authservice.istio-system.svc.cluster.local
+        port:
+          number: 8080


### PR DESCRIPTION
- Fix a missing package in the UI
- Add manifests for patching the MLX prod set up on top of multi-user Kubeflow with AppID.

Usage is the same as https://github.com/machine-learning-exchange/mlx/blob/main/docs/install-mlx-on-kubeflow.md but for our prod cluster setup. 