### PR TITLE
(ui) Add caching for api requests

### DIFF
--- a/dashboard/origin-mlx/README.md
+++ b/dashboard/origin-mlx/README.md
@@ -79,6 +79,14 @@ There are a few environment variables that can be defined that dictate how MLX i
   http://<ip_address>:<port>/<basepath>)
 * REACT_APP_BRAND - The brand name to use on the website
 * REACT_APP_DISABLE_LOGIN - A switch to turn off login mechanism
+* REACT_APP_TTL - The amount of seconds a cached entry remains valid for (24 hours by default)
+* REACT_APP_CACHE_INTERVAL - The minimum amount of time in seconds between two checks on the validity of the cache's contents (24 hours by default)
+
+# Cache Details
+
+The cache saves each request and response pair made from the UI to the API in local storage. If a request is made which matches a previous request and the difference of the time between the two requests is less than `REACT_APP_TTL` then the previously recorded response is returned. Every `REACT_APP_CACHE_INTERVAL` seconds a new check on the validity of the cache can be run. Whenever the UI is refreshed a check will be made if enough time has passed since the last cache validity check, if so then a cache validity check is started. Any item in the cache which has lasted longer than `REACT_APP_TTL` seconds is removed from the cache.
+
+To invalidate or hard reset the cache, navigate to the settings page (clicking the three dots at the bottom of the sidebar) and click on the `Reset Cache` button.
 
 # Project Overview:
 

--- a/dashboard/origin-mlx/src/App.tsx
+++ b/dashboard/origin-mlx/src/App.tsx
@@ -13,11 +13,12 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-import React, { Dispatch } from 'react';
+import React, { Dispatch, useEffect } from 'react';
 import reducer, { initial } from './lib/stores/reducer';
 import StoreContext, { Store } from './lib/stores/context';
 import { Action, State } from './lib/stores/types';
 import { GET_SETTINGS } from './lib/stores/settings';
+import { findInvalidCacheEntries } from './lib/api/artifacts';
 import { getSettings } from './lib/api/settings';
 import { getUserInfo, hasRole } from './lib/util';
 
@@ -66,6 +67,11 @@ function App() {
       break;
     }
   });
+
+  // Removes any invalid cache entries after enough time has passed since the last invalid check
+  useEffect(() => {
+    findInvalidCacheEntries()
+  })
 
   return (
     <div className="app-wrapper">

--- a/dashboard/origin-mlx/src/components/DataListItem.tsx
+++ b/dashboard/origin-mlx/src/components/DataListItem.tsx
@@ -192,6 +192,17 @@ const buildItem = (props:any) => {
         </>
       )
     }
+  } else if (itemClass === 'button') {
+    return (
+      <Button
+        className="hero-buttons upload-button" 
+        variant="contained" 
+        color="primary"
+        onClick={handleClick}
+      >
+        {name}
+      </Button>
+    )
   } else {
     return (
       <Typography 

--- a/dashboard/origin-mlx/src/components/Detail/DatasetDetail.tsx
+++ b/dashboard/origin-mlx/src/components/Detail/DatasetDetail.tsx
@@ -143,7 +143,7 @@ export default class PipelineDetail extends React.Component<IPipelineDetailProps
               <Tab 
                 className="comp-tab"
                 value="source" 
-                label="Pipeline YAML"
+                label="Dataset YAML"
               />
               { this.state.selectedGraphNode &&
                 <Tab 

--- a/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
@@ -62,6 +62,12 @@ function SidebarList() {
         />
         {artifacts && 
           <ul className="sidebar-list">
+            <SidebarListItem
+              key={"Home"}
+              name={"Home"}
+              icon={"home"}
+              active={active === 'home'}
+            />
             {artifacts
               .filter(type => type !== "workspace")
               .map(type => 
@@ -98,9 +104,9 @@ function SidebarList() {
               <SecretMenu/>
             </div>
           :
-          <div className="secret-tab" onClick={() => setSecretVisible(true)}>
-            <Icon>more_horiz</Icon>
-          </div>
+            <div className="secret-tab" onClick={() => setSecretVisible(true)}>
+              <Icon>more_horiz</Icon>
+            </div>
         )}
       </div>
     </div>

--- a/dashboard/origin-mlx/src/components/Sidebar/SidebarListItem.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/SidebarListItem.tsx
@@ -51,6 +51,9 @@ const SidebarListItem: React.FunctionComponent<SidebarListItemProps> = (props) =
   else if (props.name === 'Workspace') {
     link = 'workspace'
   }
+  else if (props.name === 'Home') {
+    link = ''
+  }
   else {
     link = 'inferenceservices'
   }

--- a/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
@@ -16,7 +16,6 @@
 import React, { useContext, useEffect, useState, Children, ReactNode, ReactElement } from 'react'
 import { capitalize, formatTitle } from '../lib/util';
 import StoreContext from '../lib/stores/context'
-import yaml from 'js-yaml'
 
 import Button from '../components/Button/Button';
 import ButtonWithTooltip from '../components/Button/ButtonWithTooltip';
@@ -25,42 +24,13 @@ import Hero from '../components/Hero';
 import Link from '../components/Link';
 import LoadingMessage from '../components/LoadingMessage';
 import PageFooter from '../components/PageFooter';
+import { fetchAssetById, fetchAssetTemplates } from '../lib/api/artifacts';
 
 interface MetaDetailPageProps {
   children: ReactNode,
   type: string,
   id: string,
   asset?: any
-}
-
-async function fetchAssetTemplates(API: string, type: string, asset: any) {
-  const res = await fetch(`${API}/apis/v1alpha1/${type}/${asset.id}/templates`)
-  const data = await res.json()
-
-  const typesWithMultipleTemplates = [ 'operators' ]
-
-  if (Array.isArray(data)) {
-    if (!typesWithMultipleTemplates.includes(type))
-      throw Error(`Received multiple templates for <${type}>. Expected one.`)
-    
-    return ({
-      ...asset,
-      templates: Object.fromEntries(await Promise.all(data.map(({ template: raw, url }: any) => {
-        const template = yaml.load(raw);
-        return [ template.kind || 'Definition', { raw, template, url } ]
-      }, data)))
-    })
-  }
-
-  return ({
-    ...asset,
-    yaml: data.template,
-    template: yaml.safeLoad(data.template)
-  })
-}
-
-async function fetchAssetById(API: string, type: string, id: string) {
-  return (await fetch(`${API}/apis/v1alpha1/${type}/${id}`)).json()
 }
 
 function MetaDetailPage(props: MetaDetailPageProps) {
@@ -74,25 +44,26 @@ function MetaDetailPage(props: MetaDetailPageProps) {
 
   useEffect(() => {
     if (!asset?.template && !asset?.templates) {
-      (asset ? Promise.resolve(asset) : fetchAssetById(API, type, id))
-        .then(asset => fetchAssetTemplates(API, type, asset))
-        .then((template: any) => {
-          if (props.asset.search) {
-            const url_params = props.asset.search.substring(1).split("&")
-            const url_params_json: {[key: string]: string} = {}
-            url_params.forEach((param: string) => {
-              const split = param.split("=")
-              if (type === "pipelines")
-                url_params_json[split[0].replace(/_/g,"-")] = split[1]
-              else
-                url_params_json[split[0]] = split[1]
-            })
-            template.url_parameters = url_params_json
-          }
-          else
-            template.url_parameters = {}
-          setAsset(template)
-        })
+      if (!asset)
+        fetchAssetById(API, type, id)
+      fetchAssetTemplates(API, type, asset)
+      .then((template: any) => {
+        if (props.asset.search) {
+          const url_params = props.asset.search.substring(1).split("&")
+          const url_params_json: {[key: string]: string} = {}
+          url_params.forEach((param: string) => {
+            const split = param.split("=")
+            if (type === "pipelines")
+              url_params_json[split[0].replace(/_/g,"-")] = split[1]
+            else
+              url_params_json[split[0]] = split[1]
+          })
+          template.url_parameters = url_params_json
+        }
+        else
+          template.url_parameters = {}
+        setAsset(template)
+      })
     }
   }, [API, asset, id, props.asset.search, type])
 

--- a/dashboard/origin-mlx/src/pages/SettingsPage.tsx
+++ b/dashboard/origin-mlx/src/pages/SettingsPage.tsx
@@ -17,6 +17,7 @@ import * as React from 'react';
 import StoreContext from '../lib/stores/context'
 import { updateSettings, resetSettings } from '../lib/api/settings';
 import { SET_SETTINGS } from '../lib/stores/settings';
+import { resetCache } from '../lib/api/artifacts';
 
 import Hero from '../components/Hero'
 import Link from '../components/Link'
@@ -365,6 +366,17 @@ export class SettingsPage extends React.Component<ISettingsPageProps, any> {
                   },
                 ]}
               />  */}
+              <DataList
+                title="Cache Settings:"
+                items={[
+                  { 
+                    itemClass: "button",
+                    name: "Reset Cache",
+                    thirdColData: "Invalidate all cache entries",
+                    handleClick: resetCache
+                  },
+                ]}
+              />
               <DataList
                 title="Artifact Types:"
                 items={Object.values(artifacts).map((setting: any) => ({ 

--- a/dashboard/origin-mlx/src/styles/Sidebar.css
+++ b/dashboard/origin-mlx/src/styles/Sidebar.css
@@ -160,7 +160,7 @@ body>* {
   width: 96%;
   margin-left: 4%;
   margin-top: 2%;
-  margin-bottom: 2%;
+  margin-bottom: 100px;
 }
 
 .footer-list-item {


### PR DESCRIPTION
Store request-response pairs in window local storage. If an identical request arises, return the response pair back instead of creating another API call.

Signed-off-by: Andrew-Butler <Andrew.Butler@ibm.com>