### PR TITLE
Expose Minio console in quickstart with Docker Compose

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -12,10 +12,11 @@ services:
       - data-minio:/data
     ports:
       - "9000:9000"
+      - "9001:9001"
     environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
-    command: server /data
+      MINIO_ROOT_USER: "minio"
+      MINIO_ROOT_PASSWORD: "minio123"
+    command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -7,7 +7,7 @@ version: '3.7'
 services:
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-07-12T02-44-53Z
     volumes:
       - data-minio:/data
     ports:


### PR DESCRIPTION
Add `--console-address ":9001"` to minio service command.

Resolves #133

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>