### PR TITLE
Disable Inference Services by default in read-only deployments

### DIFF
--- a/api/server/application_settings.yaml
+++ b/api/server/application_settings.yaml
@@ -82,6 +82,6 @@ sections:
       default: yes
       value: on
     - name: "Inference Services"
-      description: "Enable or Disable the Services section"
-      default: yes
-      value: on
+      description: "Enable or Disable the Inference Services section"
+      default: no
+      value: off


### PR DESCRIPTION
Full deployments will need to update the setting during the deployment process via the MLX API /settings endpoint.

This default value becomes important when the number of MLX-API pods gets scaled up, since the settings are not shared between MLX-API pods (each pod has their own settings file). Having multiple MLX-API pods has never been considered before.

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>