### PR TITLE
Enable anonymous read-only access for model YAMLs in Minio

### DIFF
--- a/api/server/swagger_server/controllers_impl/model_service_controller_impl.py
+++ b/api/server/swagger_server/controllers_impl/model_service_controller_impl.py
@@ -399,6 +399,8 @@ def _upload_model_yaml(yaml_file_content: AnyStr, name=None, existing_id=None):
     store_file(bucket_name="mlpipeline", prefix=f"models/{api_model.id}/",
                file_name="template.yaml", file_content=yaml_file_content)
 
+    enable_anonymous_read_access(bucket_name="mlpipeline", prefix="models/*")
+
     return api_model, 201
 
 


### PR DESCRIPTION
Enable unauthenticated read access (i.e. via `curl`) from within the K8s cluster for model YAML files stored in Minio.

@Tomcli -- can you elaborate why we need this change?

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>