### PR TITLE
[Quickstart] miniosetup depend on healthy minio service

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -24,9 +24,10 @@ services:
       retries: 3
 
   miniosetup:
-    image: minio/mc
+    image: minio/mc:RELEASE.2021-06-13T17-48-22Z
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     entrypoint: ["/bin/sh","-c"]
     command:
     - |


### PR DESCRIPTION
> https://github.com/compose-spec/compose-spec/blob/master/spec.md#long-syntax-1

>     depends_on: <svc>: 
>        condition: service_healthy

> ... specifies that a dependency is expected to be "healthy" (as indicated by healthcheck) before starting a dependent service.


Resolves #137