### PR TITLE
[API] Use waitress as production WSGI server for MLX API

### DIFF
--- a/api/server/requirements.txt
+++ b/api/server/requirements.txt
@@ -22,7 +22,10 @@ requests>=2.25.0
 Werkzeug>=1.0.1
 python_dateutil>=2.8.1
 connexion[swagger-ui]>=2.7.0
+Flask>=1.1.4
 flask-cors>=2.1.2  # https://github.com/corydolphin/flask-cors/issues/138
+
+waitress>=2.0.0
 
 PyYaml>=5.3.1
 

--- a/api/server/swagger_server/__main__.py
+++ b/api/server/swagger_server/__main__.py
@@ -14,29 +14,73 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
 
-
 import connexion
+import logging
 
+from datetime import datetime
+from flask import redirect, request
 from flask_cors import CORS
+from os import environ as env
 from swagger_server import encoder
 from swagger_server import VERSION
+from waitress import serve
+from threading import current_thread
 
 
 def main():
 
-    print(" * MLX API version: %s" % VERSION)
+    logging.basicConfig(format="%(asctime)s.%(msecs)03d %(levelname)-7s [%(name)-.8s] %(message)s",
+                        datefmt="%Y/%m/%d %H:%M:%S",
+                        level=env.get("LOGLEVEL", logging.INFO))
+
+    log = logging.getLogger("flaskapp")
+
+    log.info("MLX API version: %s" % VERSION)
 
     cx_app = connexion.App(__name__, specification_dir='./swagger/')
+    cx_app.add_api('swagger.yaml', arguments={'title': 'MLX API'})
 
     flask_app = cx_app.app
     flask_app.json_encoder = encoder.JSONEncoder
 
-    print(" * Enabled cross-origin support with 'flask-cors': origins='*'")
+    log.info("Enable cross-origin support with 'flask-cors': origins='*'")
     CORS(flask_app, origins='*')
 
-    cx_app.add_api('swagger.yaml', arguments={'title': 'MLX API'})
+    start_times = dict()
 
-    cx_app.run(port=8080)
+    def get_request_log_msg():
+        return '(%03d) %s %s %s ...' % (current_thread().ident % 1000, request.remote_addr,
+                                        request.method, request.full_path)
+
+    @flask_app.before_request
+    def before_request():
+        msg = get_request_log_msg()
+        log.info(msg)
+        start_times[msg] = datetime.now()
+
+    @flask_app.after_request
+    def after_request(response):
+        msg = get_request_log_msg()
+        time_delta = datetime.now() - start_times.pop(msg)
+        elapsed_millis = time_delta.seconds * 1000 + time_delta.microseconds / 1000
+        outstanding_requests = len(start_times)
+        log_func = get_log_method_by_response_status(response)
+        log_func('%s %s (%i ms) [%i]', msg, response.status, elapsed_millis, outstanding_requests)
+        return response
+
+    log_functions = [log.info, log.info, log.info, log.info, log.warning, log.error]
+
+    def get_log_method_by_response_status(response):
+        log_level_idx = response.status_code // 100
+        log_func = log_functions[log_level_idx]
+        return log_func
+
+    @flask_app.route("/")
+    def index():
+        return redirect("/apis/v1alpha1/ui/#!/", code=302)
+
+    # cx_app.run(port=8080)
+    serve(flask_app, host="0.0.0.0", port=8080, threads=32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #139

* Use [`waitress`](https://docs.pylonsproject.org/projects/waitress/en/latest/design.html) production-ready WSGI server to front the MLX API
* Use 32 threads to process requests in parallel
* Add request logging with response time
* Redirect index `/` requests to Swagger UI `/apis/v1alpha1/ui/`


Signed-off-by: Christian Kadner <ckadner@us.ibm.com>