### PR TITLE
Update MLX single user deployment page

### DIFF
--- a/docs/mlx-read-only-deployment.md
+++ b/docs/mlx-read-only-deployment.md
@@ -1,0 +1,17 @@
+
+## Deploy the MLX ReadOnly mode on an Existing Kubernetes Cluster
+
+To deploy the minimum MLX on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. The minimum MLX is only for Read only. To deploy the MLX ReadOnly mode on an existing Kubernetes Cluster, run the following commands
+
+This MLX ReadOnly mode only contains MLX ReadOnly deployment.
+
+```shell
+git clone https://github.com/machine-learning-exchange/mlx
+cd mlx
+kubectl apply -k manifests/read-only-k8s
+```
+
+To delete the read-only deployment, run
+```
+kubectl delete -k manifests/read-only-k8s
+```

--- a/docs/mlx-read-only-deployment.md
+++ b/docs/mlx-read-only-deployment.md
@@ -1,9 +1,7 @@
 
-## Deploy the MLX ReadOnly mode on an Existing Kubernetes Cluster
+## Deploy the MLX Read-Only mode on an Existing Kubernetes Cluster
 
-To deploy the minimum MLX on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. The minimum MLX is only for Read only. To deploy the MLX ReadOnly mode on an existing Kubernetes Cluster, run the following commands
-
-This MLX ReadOnly mode only contains MLX ReadOnly deployment.
+To deploy MLX in read-only mode on an existing Kubernetes cluster without Kubeflow, clone the MLX repo and apply the manifest using Kustomize:
 
 ```shell
 git clone https://github.com/machine-learning-exchange/mlx

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -2,14 +2,14 @@
 
 To deploy the MLX single user mode on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. This MLX deployment doesn't include model serving with KFServing. To experience the other MLX features such as KFServing, multi-user, and Istio mutual TLS, please install the extra plugins by follow one of the instructions on the [main README](/README.md/#2-deployment).
 
-This MLX contains:
+This MLX deployment includes:
 - Istio
 - Kubeflow Pipeline single user
 - Tekton Pipeline
 - Datashim
 - MLX
 
-We will be using [kustomize 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) to align with Kubeflow's requirements because we will be also install kubeflow components as part of this MLX deployment.
+We are using [kustomize 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) to align with Kubeflow's requirements because we will install kubeflow components as part of this MLX deployment.
 
 ```shell
 git clone https://github.com/machine-learning-exchange/manifests -b mlx-single-user

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -1,14 +1,15 @@
-## Deploy the Minimum MLX Stack on an Existing Kubernetes Cluster
+## Deploy the MLX Stack on an Existing Kubernetes Cluster
 
-To deploy the minimum MLX on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. The minimum MLX is only for running basic pipelines on MLX which doesn't support dataset deployment and model serving with KFServing. To experience the other MLX features, please follow one of the instructions on the [main README](/README.md/#2-deployment).
+To deploy the MLX single user mode on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. This MLX deployment doesn't include model serving with KFServing. To experience the other MLX features such as KFServing, multi-user, and Istio mutual TLS, please install the extra plugins by follow one of the instructions on the [main README](/README.md/#2-deployment).
 
-This minimum MLX contains:
+This MLX contains:
 - Istio
 - Kubeflow Pipeline single user
 - Tekton Pipeline
+- Datashim
 - MLX
 
-We will be using [kustomize 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) to align with Kubeflow's requirements because we will be using kubeflow pipelines as the MLX pipeline engine.
+We will be using [kustomize 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) to align with Kubeflow's requirements because we will be also install kubeflow components as part of this MLX deployment.
 
 ```shell
 git clone https://github.com/machine-learning-exchange/manifests -b mlx-single-user
@@ -19,14 +20,10 @@ while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply
 Then access the MLX page using http://<cluster_node_ip>:30380/mlx/
 
 
-## Deploy the MLX ReadOnly mode on an Existing Kubernetes Cluster
+## Delete the MLX deployment
 
-To deploy the MLX ReadOnly mode on an existing Kubernetes Cluster, run the following commands
+To delete the above MLX deployment, simply run the following commands in the same repo.
 
-This MLX ReadOnly mode only contains MLX ReadOnly deployment.
-
-```shell
-git clone https://github.com/machine-learning-exchange/mlx
-cd mlx
-kubectl apply -k manifests/read-only-k8s
+```
+kustomize build example | kubectl delete -f -
 ```

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -16,7 +16,7 @@ This MLX deployment includes:
 - Datashim
 - MLX
 
-We are using [kustomize 3.2.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) to align with Kubeflow's requirements because we will install kubeflow components as part of this MLX deployment.
+This MLX deployment doesn't include model serving with KFServing. To experience the other MLX features such as KFServing, multi-user mode, and Istio mutual TLS, please install the extra plugins by following the instructions on [deploying it on an existing Kubeflow](/docs/install-mlx-on-kubeflow.md#deploy-mlx-on-an-existing-kubeflow-cluster).
 
 ```shell
 git clone https://github.com/machine-learning-exchange/manifests -b mlx-single-user

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -7,7 +7,7 @@
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
 * [`kustomize v3.0+`](https://kubernetes-sigs.github.io/kustomize/installation/) is installed
 
-To deploy the MLX single user mode on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. This MLX deployment doesn't include model serving with KFServing. To experience the other MLX features such as KFServing, multi-user, and Istio mutual TLS, please install the extra plugins by follow one of the instructions on the [main README](/README.md/#2-deployment).
+To deploy the MLX single user mode on an existing Kubernetes Cluster, clone the MLX manifests and deploy it with Kustomize. 
 
 This MLX deployment includes:
 - Istio

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -1,4 +1,11 @@
-## Deploy the MLX Stack on an Existing Kubernetes Cluster
+# Deploy MLX on an existing Kubernetes cluster
+
+## Prerequisites
+* An existing Kubernetes cluster. Version 1.17+
+* The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
+* If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
+* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
+* [`kustomize v3.0+`](https://kubernetes-sigs.github.io/kustomize/installation/) is installed
 
 To deploy the MLX single user mode on an existing Kubernetes Cluster, we can clone the MLX manifests and deploy it with Kustomize. This MLX deployment doesn't include model serving with KFServing. To experience the other MLX features such as KFServing, multi-user, and Istio mutual TLS, please install the extra plugins by follow one of the instructions on the [main README](/README.md/#2-deployment).
 


### PR DESCRIPTION
Update MLX single user deployment page to include delete instructions and move the Read-only mode to a hidden readme.

Note: For datashim there's no official release, so we will be using the latest images at the moment.