### PR TITLE
[API] Add missing parameters to NotebookOp

### DIFF
--- a/api/server/swagger_server/code_templates/run_notebook.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/run_notebook.TEMPLATE.py
@@ -24,8 +24,8 @@ from tempfile import gettempdir
 ############################################################
 
 @dsl.pipeline(
-  name='Run a Jupyter Notebook',
-  description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
+    name='Run Jupyter Notebook ${name}',
+    description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
 )
 def notebook_pipeline():
     """A pipeline to run a Jupyter notebook with elyra-ai/kfp-notebook and Papermill."""
@@ -33,6 +33,8 @@ def notebook_pipeline():
     from kfp_notebook.pipeline import NotebookOp
 
     notebook_op = NotebookOp(name="${name}",
+                             pipeline_name="run-jupyter-notebook-${name}",
+                             experiment_name="NOTEBOOK_RUNS",
                              notebook="${notebook}",
                              cos_endpoint="${cos_endpoint}",
                              cos_bucket="${cos_bucket}",

--- a/api/server/swagger_server/code_templates/run_notebook.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/run_notebook.TEMPLATE.py
@@ -24,8 +24,8 @@ from tempfile import gettempdir
 ############################################################
 
 @dsl.pipeline(
-    name='Run Jupyter Notebook ${name}',
-    description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
+    name='${name}',
+    description='${description}'
 )
 def notebook_pipeline():
     """A pipeline to run a Jupyter notebook with elyra-ai/kfp-notebook and Papermill."""
@@ -33,7 +33,7 @@ def notebook_pipeline():
     from kfp_notebook.pipeline import NotebookOp
 
     notebook_op = NotebookOp(name="${name}",
-                             pipeline_name="run-jupyter-notebook-${name}",
+                             pipeline_name="${name}",
                              experiment_name="NOTEBOOK_RUNS",
                              notebook="${notebook}",
                              cos_endpoint="${cos_endpoint}",

--- a/api/server/swagger_server/code_templates/run_notebook_with_dataset.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/run_notebook_with_dataset.TEMPLATE.py
@@ -24,8 +24,8 @@ from tempfile import gettempdir
 ############################################################
 
 @dsl.pipeline(
-  name='Run a Jupyter Notebook',
-  description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
+    name='Run Jupyter Notebook ${name}',
+    description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
 )
 def notebook_pipeline():
     """A pipeline to run a Jupyter notebook with elyra-ai/kfp-notebook and Papermill."""
@@ -33,6 +33,8 @@ def notebook_pipeline():
     from kfp_notebook.pipeline import NotebookOp
 
     notebook_op = NotebookOp(name="${name}",
+                             pipeline_name="run-jupyter-notebook-${name}",
+                             experiment_name="NOTEBOOK_RUNS",
                              notebook="${notebook}",
                              cos_endpoint="${cos_endpoint}",
                              cos_bucket="${cos_bucket}",

--- a/api/server/swagger_server/code_templates/run_notebook_with_dataset.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/run_notebook_with_dataset.TEMPLATE.py
@@ -24,8 +24,8 @@ from tempfile import gettempdir
 ############################################################
 
 @dsl.pipeline(
-    name='Run Jupyter Notebook ${name}',
-    description='A pipeline to run a Jupyter notebook using the elyra-ai/kfp-notebook library.'
+    name='${name}',
+    description='${description}'
 )
 def notebook_pipeline():
     """A pipeline to run a Jupyter notebook with elyra-ai/kfp-notebook and Papermill."""
@@ -33,7 +33,7 @@ def notebook_pipeline():
     from kfp_notebook.pipeline import NotebookOp
 
     notebook_op = NotebookOp(name="${name}",
-                             pipeline_name="run-jupyter-notebook-${name}",
+                             pipeline_name="${name}",
                              experiment_name="NOTEBOOK_RUNS",
                              notebook="${notebook}",
                              cos_endpoint="${cos_endpoint}",

--- a/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
+++ b/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
@@ -20,6 +20,7 @@ import yaml
 from datetime import datetime
 
 from kfp import Client as KfpClient
+from kfp.compiler.compiler import sanitize_k8s_name
 
 from kfp_server_api import ApiRun
 from kfp_server_api import ApiPipeline as KfpPipeline
@@ -481,10 +482,15 @@ def generate_notebook_run_script(api_notebook: ApiNotebook,
     # output_file_path = f"{output_folder}/{output_file_name}"
     # output_file_url = f"http://{minio_host}:{minio_port}/mlpipeline/{output_file_path}"
 
+    # TODO: do we really need this url:
+    #   client = TektonClient(${pipeline_server})
+    # vs:
+    #   client = TektonClient()
+    # ... kfp.Client can figure out the in-cluster IP and port automatically
     kfp_url = f"'{_pipeline_service_url}'" if "POD_NAMESPACE" not in os.environ else ""
 
     substitutions = {
-        "name": api_notebook.name,
+        "name": sanitize_k8s_name(api_notebook.name),
         "notebook": notebook_file,
         "cos_bucket": "mlpipeline",
         "cos_directory": f"notebooks/{api_notebook.id}/",

--- a/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
+++ b/api/server/swagger_server/gateways/kubeflow_pipeline_service.py
@@ -20,7 +20,6 @@ import yaml
 from datetime import datetime
 
 from kfp import Client as KfpClient
-from kfp.compiler.compiler import sanitize_k8s_name
 
 from kfp_server_api import ApiRun
 from kfp_server_api import ApiPipeline as KfpPipeline
@@ -490,7 +489,8 @@ def generate_notebook_run_script(api_notebook: ApiNotebook,
     kfp_url = f"'{_pipeline_service_url}'" if "POD_NAMESPACE" not in os.environ else ""
 
     substitutions = {
-        "name": sanitize_k8s_name(api_notebook.name),
+        "name": api_notebook.name,
+        "description": api_notebook.description,
         "notebook": notebook_file,
         "cos_bucket": "mlpipeline",
         "cos_directory": f"notebooks/{api_notebook.id}/",


### PR DESCRIPTION
Resolves #147

Add parameters `pipeline_name` and `experiment_name` to `NotebookOp()` initialization.