### PR TITLE
Update MLX with Kubeflow manifests prerequisites to install kustomize 3.2.0

### DIFF
--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -6,9 +6,9 @@
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
 * [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
-   * Kustomize v3.2.0 quick install. For MacOS, keep the OS value as darwin. For linux, please update the OS value to `linux`.
+   * Kustomize v3.2.0 quick install:
    ```
-   OS=darwin 
+   OS=$(uname) 
    curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_${OS}_amd64 --output kustomize
    chmod +x kustomize
    mv kustomize /usr/local/bin

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -5,7 +5,14 @@
 * The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
-* [`kustomize v3.0+`](https://kubernetes-sigs.github.io/kustomize/installation/) is installed
+* [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
+   * Kustomize v3.2.0 quick install. For MacOS, keep the OS value as darwin. For linux, please update the OS value to `linux`.
+   ```
+   OS=darwin 
+   curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_${OS}_amd64 --output kustomize
+   chmod +x kustomize
+   mv kustomize /usr/local/bin
+   ```
 
 ## Deploy
 


### PR DESCRIPTION
Revert and enhance the MLX with Kubeflow instructions from #146 to only install kustomize version 3.2.0 due to Kubeflow's current limitation https://github.com/kubeflow/manifests#prerequisites. 