### PR TITLE
Fix quickstart startup sequence

### DIFF
--- a/api/examples/pipelines_api.py
+++ b/api/examples/pipelines_api.py
@@ -453,11 +453,11 @@ def main():
     # delete the pipeline we just uploaded
     delete_pipeline(pipeline_id)
 
-    # set featured pipelines
-    set_featured_pipelines(pipeline_ids)
-
     # approve pipelines to be published
-    approve_pipelines_for_publishing(pipeline_ids)
+    approve_pipelines_for_publishing(pipeline_ids[:7])
+
+    # set featured pipelines
+    set_featured_pipelines(pipeline_ids[:4])
 
     # randomly selected a pipeline
     i = random.randint(0, len(pipeline_ids)-1)

--- a/api/server/Dockerfile
+++ b/api/server/Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHON_PIP_VERSION 20.2.4
 
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST 1
 
-RUN apk add --update --virtual=build-dependencies \
+RUN apk add --update --virtual build-dependencies \
         pkgconfig \
         openssl-dev \
         libffi-dev \

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -29,7 +29,19 @@ Clone this repository and navigate to the `quickstart` folder:
     git clone https://github.com/machine-learning-exchange/mlx.git
     cd mlx/quickstart
 
+## Keep up to date
+
+If some time has passed since the `mlx` repository was cloned, 
+make sure to pull the latest sources for the _Quickstart_:
+
+    git pull
+
 ## Pull the Docker Images
+
+Our Docker images for the [mlx-api](https://hub.docker.com/r/mlexchange/mlx-api/tags?name=nightly)
+and
+[mlx-ui](https://hub.docker.com/r/mlexchange/mlx-ui/tags?name=nightly) 
+get rebuilt nightly. To get the latest version, run:
 
     docker compose pull
 

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -19,9 +19,9 @@ services:
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   miniosetup:
     image: minio/mc:RELEASE.2021-06-13T17-48-22Z
@@ -47,6 +47,11 @@ services:
     volumes:
       - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
       - data-mysql:/var/lib/mysql
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   mlx-api:
     image: mlexchange/mlx-api:nightly-main
@@ -59,6 +64,11 @@ services:
       MYSQL_SERVICE_PORT: "3306"
       ML_PIPELINE_SERVICE_HOST: "UNAVAILABLE"
       ML_PIPELINE_SERVICE_PORT: "UNAVAILABLE"
+#    healthcheck:  # disable healthcheck, it's filling up the logs
+#      test: [ "CMD", "wget", "-qO-", 'http://localhost:8080/apis/v1alpha1/health_check?check_database=true&check_object_store=true' ]
+#      interval: 5s
+#      timeout: 5s
+#      retries: 10
 
   mlx-ui:
     image: mlexchange/mlx-ui:nightly-origin-main
@@ -76,9 +86,12 @@ services:
   catalog:
     image: curlimages/curl
     depends_on:
-      - minio
-      - mysql
-      - mlx-api
+      miniosetup:
+        condition: service_completed_successfully
+      mysql:
+        condition: service_healthy
+      mlx-api:
+        condition: service_started  # NOT service_healthy as that pollutes the logs
     volumes:
       - ./catalog_upload.json:/catalog_upload.json
       - ./init_catalog.sh:/init_catalog.sh


### PR DESCRIPTION
**Changes:**

* Shorten intervals for `minio` `healthcheck` from `30s` to `5s`
* Add `healthcheck` to `mysql` service
* Do **not** add `healthcheck` to `mlx-api` (logs fill up)
* Change `catalog` service dependencies to wait for `miniosetup` to _complete_ and `mysql` to be _healthy_

Resolves #173