### PR TITLE
Adding CodeNet Dataset

### DIFF
--- a/quickstart/catalog_upload.json
+++ b/quickstart/catalog_upload.json
@@ -35,10 +35,6 @@
   ],
   "datasets": [
     {
-      "name": "Thematic Clustering",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/thematic_clustering.yaml"
-    },
-    {
       "name": "Finance Proposition Bank",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/fpb.yaml"
     },
@@ -49,6 +45,10 @@
     {
       "name": "NOAA Weather Data",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/jfk.yaml"
+    },
+    {
+      "name": "Project CodeNet Dataset",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/codenet.yaml"
     },
     {
       "name": "PubLayNet",
@@ -63,8 +63,8 @@
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/tsc.yaml"
     },
     {
-      "name": "CodeNet Dataset",
-      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/codenet.yaml"
+      "name": "Thematic Clustering",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/thematic_clustering.yaml"
     }
   ],
   "models": [
@@ -125,6 +125,14 @@
     {
       "name": "JFK Airport Analysis",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/JFK-airport.yaml"
+    },
+    {
+      "name": "Project CodeNet Language Classification",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/codenet-lang.yaml"
+    },
+    {
+      "name": "Project CodeNet Masked Language Model",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/notebook-samples/codenet-mlm.yaml"
     }
   ],
   "pipelines": [

--- a/quickstart/catalog_upload.json
+++ b/quickstart/catalog_upload.json
@@ -61,6 +61,10 @@
     {
       "name": "TensorFlow Speech Commands",
       "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/tsc.yaml"
+    },
+    {
+      "name": "CodeNet Dataset",
+      "url": "https://raw.githubusercontent.com/machine-learning-exchange/katalog/main/dataset-samples/codenet.yaml"
     }
   ],
   "models": [


### PR DESCRIPTION
This commit adds the name and URL for the CodeNet dataset to the Quickstart `catalog_upload.json`

Project CodeNet is a large-scale dataset with approximately 14 million code samples (written in over 50 programming languages), each of which is an intended solution to one of 4000 coding problems.

https://developer.ibm.com/technologies/artificial-intelligence/data/project-codenet/

**Related work items:**
- [x] https://github.com/machine-learning-exchange/katalog/pull/14

**Outstanding work items:**
- [ ] Add the CodeNet dataset to the `bootstrapper/catalog_upload.json`
- [ ] Add the CodeNet notebooks to the `bootstrapper/catalog_upload.json` and `quickstart/catalog_upload.json`

@ckadner
(pithas@RPI.edu)