### PR TITLE
Reformat sidebar to account for small screens

### DIFF
--- a/dashboard/origin-mlx/src/components/Sidebar/Sidebar.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/Sidebar.tsx
@@ -38,7 +38,8 @@ function Sidebar(props: { children: ReactNode }) {
         sidebar:{
           "color": sideNavColors.fgActive,
           "backgroundColor": sideNavColors.bg,
-          "width":"230px"
+          "width":"230px",
+          "overflow":"hidden"
         }
       }}
     >

--- a/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
+++ b/dashboard/origin-mlx/src/components/Sidebar/SidebarList.tsx
@@ -13,7 +13,7 @@
 *  See the License for the specific language governing permissions and 
 *  limitations under the License. 
 */ 
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import StoreContext from '../../lib/stores/context'
 import SidebarHeader from './SideBarHeader';
 import SidebarListItem from './SidebarListItem';
@@ -34,6 +34,29 @@ const sideNavColors = {
 
 const isAdmin = hasRole(getUserInfo(), 'admin');
 
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+
+function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}
+
 function SidebarList() {
   const { store } = useContext(StoreContext)
   const { settings, pages } = store
@@ -47,10 +70,15 @@ function SidebarList() {
 
   const artifacts = Object.keys(store.settings.artifacts).filter(enabled).filter((artifact: string) => {return artifact !== "workspace" && artifact !== "operators"})
   const [secretVisible, setSecretVisible] = useState(false)
+  const { height } = useWindowDimensions()
+  // Ensures the "Join the Conversation" button is away from the other buttons (if there is enough space)
+  const guardHeight = height > 700 ? (height - 670) / 2 : 0
+
+  console.log(height)
 
   return (
     <div className="sidebar-container">
-      <div 
+      <div
         style={{
           "textAlign": "left",
           "color": sideNavColors.fgActive,
@@ -87,18 +115,17 @@ function SidebarList() {
                 active={'Workspace' === active}
               />
             }
+            <div style={{"height": guardHeight}}></div>
+            <Link to="/external-links">
+              <h3 className={`sidebar-list-item footer-list-item ${false ? 'active' : 'not-active'}`}>
+                <Icon className="sidebar-icon">chat</Icon>
+                Join the Conversation
+              </h3>
+            </Link>
           </ul>
         }
       </div>
       <div className="bottom-sidebar">
-        <div className={"sidebar-list-wrap footer-list-wrap" + (!secretVisible ? " conversation-margin" : "")}>
-          <Link to="/external-links">
-            <h3 className={`sidebar-list-item footer-list-item ${false ? 'active' : 'not-active'}`}>
-              <Icon className="sidebar-icon">chat</Icon>
-              Join the Conversation
-            </h3>
-          </Link>
-        </div>
         { !secretVisible &&
           <div className="secret-divider"></div>
         }
@@ -108,10 +135,13 @@ function SidebarList() {
             </div>
           :
             <div className="secret-tab" onClick={() => setSecretVisible(true)}>
-              <Icon>more_horiz</Icon>
+              <div className="display-secret-menu-button">
+                <Icon>settings</Icon> 
+                <h3 className="secret-title">Settings</h3>
+              </div>
             </div>
         )}
-      </div>
+        </div>
     </div>
   )
 }

--- a/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
@@ -44,28 +44,6 @@ function MetaDetailPage(props: MetaDetailPageProps) {
   const { api } = store.settings.endpoints
   const API = api.value || api.default
 
-  const fetchTemplates = () => {
-    fetchAssetTemplates(API, type, asset)
-    .then((template: any) => {
-      if (props.asset.search) {
-        const url_params = props.asset.search.substring(1).split("&")
-        const url_params_json: {[key: string]: string} = {}
-        url_params.forEach((param: string) => {
-          const split = param.split("=")
-          let key = decodeURIComponent(split[0])
-          const value = decodeURIComponent(split[1])
-          if (type === "pipelines")
-            key = key.replace(/_/g,"-")
-          url_params_json[key] = value
-        })
-        template.url_parameters = url_params_json
-      }
-      else
-        template.url_parameters = {}
-      setAsset(template)
-    })
-  }
-
   useEffect(() => {
     if (!asset?.template && !asset?.templates) {
       if (!asset) {
@@ -83,7 +61,25 @@ function MetaDetailPage(props: MetaDetailPageProps) {
         });
       }
       else {
-        fetchTemplates()
+        fetchAssetTemplates(API, type, asset)
+        .then((template: any) => {
+          if (props.asset.search) {
+            const url_params = props.asset.search.substring(1).split("&")
+            const url_params_json: {[key: string]: string} = {}
+            url_params.forEach((param: string) => {
+              const split = param.split("=")
+              let key = decodeURIComponent(split[0])
+              const value = decodeURIComponent(split[1])
+              if (type === "pipelines")
+                key = key.replace(/_/g,"-")
+              url_params_json[key] = value
+            })
+            template.url_parameters = url_params_json
+          }
+          else
+            template.url_parameters = {}
+          setAsset(template)
+        })
       }
     }
   }, [API, asset, id, props.asset.search, type])

--- a/dashboard/origin-mlx/src/styles/Sidebar.css
+++ b/dashboard/origin-mlx/src/styles/Sidebar.css
@@ -107,7 +107,6 @@ body>* {
 
 .bottom-sidebar {
   width: 100%;
-  height: 200px;
   position: absolute;
   bottom: 0;
   left: 0;
@@ -121,11 +120,40 @@ body>* {
   margin-bottom: 5px;
 }
 
+.display-secret-menu-button {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 5px;
+}
+
+.secret-title {
+  margin: 0;
+}
+
+.secret-tab-open {
+  width: 100%;
+  background-color: rgb(48, 48, 48);
+}
+
+.secret-tab {
+  display: flex;
+  flex-direction: row;
+  background-color: rgb(48, 48, 48);
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  padding-top: 17px;
+}
+
 .secret-tab:hover {
   color: darkcyan;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+.secret-tab:hover {
+  padding-top: 0;
 }
 
 .secret-tab:hover::before {
@@ -168,6 +196,6 @@ body>* {
 }
 
 .footer-list-item {
-  width: 100%;
-  margin: 0%;
+  width: 96%;
+  margin: 0 0 0 4%;
 }


### PR DESCRIPTION
Signed-off-by: Andrew-Butler <Andrew.Butler@ibm.com>

Related: #168 

> (prio 1) Join the conversation / Notebooks links are overlapping in Firefox 90.0.2 (64-bit) - RHEL 8.3
> please just make it part of the list of asset types

Addresses issue mentioned in #168 as well as making the settings button more noticeable and some extra css changes to address other sidebar issues.

For large screens:
<img width="1662" alt="Screen Shot 2021-08-18 at 11 44 04 AM" src="https://user-images.githubusercontent.com/32145094/129954529-28f6759a-a6b6-42d9-af96-b9285443fb86.png">
For small screens:
<img width="1679" alt="Screen Shot 2021-08-18 at 11 44 30 AM" src="https://user-images.githubusercontent.com/32145094/129954539-2f2a9b65-2b79-422c-913e-c52f689ecb37.png">
