### PR TITLE
[API] Provide module `__name__` (again) to initialize FlaskApp (#189)

### DIFF
--- a/api/server/.dockerignore
+++ b/api/server/.dockerignore
@@ -58,7 +58,9 @@ coverage.xml
 *,cover
 .hypothesis/
 venv/
+.venv/
 .python-version
+test/
 
 # Translations
 *.mo

--- a/api/server/Dockerfile
+++ b/api/server/Dockerfile
@@ -35,6 +35,8 @@ RUN pip list
 
 COPY . /usr/src/app
 
+RUN ls */*
+
 EXPOSE 8080
 
 ENTRYPOINT ["python3"]

--- a/api/server/mlx-api.yml
+++ b/api/server/mlx-api.yml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: mlx-api
       containers:
       - name: mlx-api-server
-        image: docker.io/aipipeline/mlx-api:nightly-main
+        image: docker.io/mlexchange/mlx-api:nightly-main
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/api/server/swagger_server/__main__.py
+++ b/api/server/swagger_server/__main__.py
@@ -37,7 +37,7 @@ def main():
 
     log.info("MLX API version: %s" % VERSION)
 
-    cx_app = connexion.App("MLX-API", specification_dir='./swagger/')
+    cx_app = connexion.App(__name__, specification_dir='./swagger/')
     cx_app.add_api('swagger.yaml', arguments={'title': 'MLX API'})
 
     flask_app = cx_app.app


### PR DESCRIPTION
### Description of changes:

* FlaskApp requires module `__name__` to find Swagger spec
* Add `ls` command to Dockerfile for easier debugging
* Update DockerHub org to `mlexchange` for `mlx-api` deployment
* Don't include test files or Python virtual environment files in the Docker image

Resolves #189

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>