### PR TITLE
Update the `pip`-install code blocks in API docs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -50,12 +50,6 @@ will automatically download the _"correct"_ version of the `swagger-codegen-cli.
 
     python3 -m venv .venv
     source .venv/bin/activate
-
-    # force pip to use legacy dependency version conflict resolver
-    # "kfserving 0.4.1 requires kubernetes==10.0.1, but you'll have kubernetes 11.0.0 which is incompatible."
-    export PYTHON_PIP_VERSION=20.2.4
-    pip install pip=="$PYTHON_PIP_VERSION" --force-reinstall
-
     pip install -r ./requirements.txt
 
 ## (Re-)Generate Swagger Client and Server Code

--- a/api/server/README.md
+++ b/api/server/README.md
@@ -9,15 +9,14 @@ Flask server.
 This example uses the [Connexion](https://github.com/zalando/connexion) library on top of Flask.
 
 ## Requirements
-Python 3.5.2+
+Python 3.6.1+
 
 ## Usage
 
 To run the server, please execute the following from the root directory:
 
 ```
-pip3 install -r requirements.txt --use-deprecated=legacy-resolver
-pip3 install 'connexion[swagger-ui]'  # https://stackoverflow.com/a/57207557/5601796
+pip3 install -r requirements.txt
 python3 -m swagger_server
 ```
 

--- a/api/server/requirements.txt
+++ b/api/server/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.25.0
 Werkzeug>=1.0.1
 python_dateutil>=2.8.1
 connexion[swagger-ui]>=2.7.0
-Flask>=1.1.4 #,<2.0.0
+Flask>=1.1.4,<2.0.0  #  Flask>2.0.0 requires Werkzeug>=2.0, but connexion[swagger-ui]==2.9.0 requires werkzeug<2.0,>=1.0
 flask-cors>=2.1.2  # https://github.com/corydolphin/flask-cors/issues/138
 waitress>=2.0.0
 


### PR DESCRIPTION
* Remove references to `pip` legacy resolver
* Update minimum Python version to `3.6`
* Remove separate installation step for `connexion[swagger-ui]`
* Restrict `Flask` version tolerance to `1.1.4...2.0.0`, since 
  * `Flask>2.0.0` requires `Werkzeug>=2.0`, but
  * `connexion[swagger-ui]==2.9.0` requires `werkzeug<2.0`

Related: #203
