### PR TITLE
[API] Don't cache KFServices

### DIFF
--- a/api/server/swagger_server/__init__.py
+++ b/api/server/swagger_server/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "0.1.29-filter-categories"
+VERSION = "0.1.29-dont-cache-kfservices"

--- a/api/server/swagger_server/__main__.py
+++ b/api/server/swagger_server/__main__.py
@@ -27,6 +27,11 @@ from waitress import serve
 from threading import current_thread
 
 
+def get_request_log_msg():
+    return '(%03d) %s %s %s ...' % (current_thread().ident % 1000, request.remote_addr,
+                                    request.method, request.full_path)
+
+
 def main():
 
     logging.basicConfig(format="%(asctime)s.%(msecs)03d %(levelname)-7s [%(name)-.8s] %(message)s",
@@ -47,10 +52,6 @@ def main():
     CORS(flask_app, origins='*')
 
     start_times = dict()
-
-    def get_request_log_msg():
-        return '(%03d) %s %s %s ...' % (current_thread().ident % 1000, request.remote_addr,
-                                        request.method, request.full_path)
 
     @flask_app.before_request
     def before_request():

--- a/api/server/swagger_server/swagger/swagger.yaml
+++ b/api/server/swagger_server/swagger/swagger.yaml
@@ -15,7 +15,7 @@
 swagger: "2.0"
 info:
   description: "MLX API Extension for Kubeflow Pipelines"
-  version: "0.1.29-filter-categories"
+  version: "0.1.29-dont-cache-kfservices"
   title: "MLX API"
 basePath: "/apis/v1alpha1"
 schemes:

--- a/api/server/swagger_server/util.py
+++ b/api/server/swagger_server/util.py
@@ -18,6 +18,7 @@ import six
 import typing
 
 from flask import request
+from swagger_server.__main__ import get_request_log_msg
 
 
 def _deserialize(data, klass):
@@ -189,6 +190,12 @@ class ApiError(Exception):
 response_cache = dict()
 
 
+def should_cache(controller_name, method_name):
+    return request.method == "GET" \
+           and method_name != "health_check" \
+           and "inference_service" not in controller_name
+
+
 def invoke_controller_impl(controller_name=None, parameters=None, method_name=None):
     """
     Invoke the controller implementation of the method called on the parent frame.
@@ -266,14 +273,16 @@ def invoke_controller_impl(controller_name=None, parameters=None, method_name=No
             results = None
             request_cache_key = (controller_name, method_name, str(parameters))
 
-            if request.method == "GET" and method_name != "health_check":
+            if should_cache(controller_name, method_name):
                 results = response_cache.get(request_cache_key)
 
             if not results:
                 results = impl_func(**parameters)
 
-                if request.method == "GET" and method_name != "health_check":
+                if should_cache(controller_name, method_name):
                     response_cache[request_cache_key] = results
+                    log_msg = get_request_log_msg()
+                    logging.getLogger("GETcache").info(f"{log_msg} added to cache")
 
                 if request.method in ("DELETE", "POST", "PATCH", "PUT") and not method_name.startswith("run_"):
                     # any modifying method clears all cached entries, to avoid loopholes like delete '*',
@@ -299,4 +308,3 @@ def invoke_controller_impl(controller_name=None, parameters=None, method_name=No
 
     else:
         return f'Method not found: {module_name}.{method_name}()', 501
-


### PR DESCRIPTION
KFServices do not get updated via the API, so there will be no POST, PATCH, DELETE request to update the API cache.

Signed-off-by: Christian Kadner <ckadner@us.ibm.com>