### PR TITLE
Add tags from filter_categories

### DIFF
--- a/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
@@ -80,7 +80,7 @@ function MetaCard(props: MetaCardProps) {
 
   const description = firstSentence(props.description || 'Component for your Pipelines.')
 
-  const tags = asset.filter_categories 
+  let tags = asset.filter_categories 
     ? Object.keys(asset.filter_categories).flatMap((key: any) => {
         const value = asset.filter_categories[key]
         if (value.substring(0,1) === "[") {
@@ -91,6 +91,11 @@ function MetaCard(props: MetaCardProps) {
         }
       })
     : []
+
+  // Temporarily limit the number of tags to 3
+  if (tags.length > 3) {
+    tags = tags.slice(0,3)
+  }
 
   const logo = getLogo(framework)
 

--- a/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
@@ -80,7 +80,18 @@ function MetaCard(props: MetaCardProps) {
 
   const description = firstSentence(props.description || 'Component for your Pipelines.')
 
-  const tags = Object.keys(asset.filter_categories).map((key: any) => asset.filter_categories[key])
+  const tags = asset.filter_categories 
+    ? Object.keys(asset.filter_categories).flatMap((key: any) => {
+        const value = asset.filter_categories[key]
+        if (value.substring(0,1) === "[") {
+          return JSON.parse(value.replaceAll("'", "\""))
+        }
+        else {
+          return value
+        }
+      })
+    : []
+
   const logo = getLogo(framework)
 
   return (

--- a/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaFeaturedPage/MetaCard.tsx
@@ -80,7 +80,7 @@ function MetaCard(props: MetaCardProps) {
 
   const description = firstSentence(props.description || 'Component for your Pipelines.')
 
-  const tags = tag.includes(',') ? tag.split(',') : [tag]
+  const tags = Object.keys(asset.filter_categories).map((key: any) => asset.filter_categories[key])
   const logo = getLogo(framework)
 
   return (


### PR DESCRIPTION
Adds the tags from asset.filter_categories into the Featured Page cards.
Signed-off-by: Andrew-Butler <Andrew.Butler@ibm.com>

<img width="1215" alt="Screen Shot 2021-09-09 at 9 32 13 AM" src="https://user-images.githubusercontent.com/32145094/132726192-1c8dc1ef-52c4-4559-8807-6e9fa871de6e.png">
