### PR TITLE
Move Copyright notice to bottom of page, Issue #215

### DIFF
--- a/dashboard/origin-mlx/src/styles/Models.css
+++ b/dashboard/origin-mlx/src/styles/Models.css
@@ -184,7 +184,7 @@ td>span.checked {
 
 .footer-text {
   color: #ddd;
-  margin-top: 2%;
+  margin-top: 9%;
   margin-bottom: 0%;
   margin-left: 0.5%;
   margin-right: 0.5%;


### PR DESCRIPTION
`https://github.com/machine-learning-exchange/mlx/issues/215`

Moves the copyright notice to the bottom of the page by increasing container's top margin.