### PR TITLE
API development with Docker Compose

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,6 +2,8 @@
 
 An extension to the Kubeflow Pipeline API for Components and Models
 
+---
+
 # Quickstart    
 
 ## Deploy to Kubernetes
@@ -117,7 +119,10 @@ Optional, to delete all data in Minio and MySQL, run the following commands:
 
 ### TERMINAL 2 - Swagger Server
 
-Bring up the API code and set the required environment variables to connect to MySQL and Minio 
+Bring up the API code and set the required environment variables to connect to MySQL and Minio.
+
+Make sure to have activated you Python virtual environment with the required package dependencies
+installed as described [above](#create-a-python-virtual-environment-for-development).
 
     # cd <mlx_root_dir>
     cd api/server/swagger_server

--- a/api/README.md
+++ b/api/README.md
@@ -76,3 +76,63 @@ or:
 
     kubectl delete -f ./server/mlx-api.yml
     kubectl apply -f ./server/mlx-api.yml
+
+## Testing API Code Changes with Docker Compose
+
+You can test most code changes without a Kubernetes cluster. A K8s cluster is only
+required to `run` the generated sample pipeline code. Running the Quickstart with
+Docker Compose is sufficient to test any `katalog` related API endpoints.
+
+A development setup that works very well requires to 3 shell terminals:
+
+### Terminal 1 - Quickstart without `mlx-api` service
+
+Bring up the Quickstart without the `mlx-api` service, since we will run the MLX API
+from our local source code, instead of using the pre-built Docker image `mlexchange/mlx-api:nightly-main`.
+
+    # cd <mlx_root_directory>
+    cd quickstart
+    
+    docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui
+
+After testing or debugging your code changes, bring down the Docker Compose stack:
+
+    # control + C 
+
+    docker compose --project-name  no_api  down  minio miniosetup mysql mlx-ui
+
+Optional, to delete all data in Minio and MySQL, run the following commands:
+
+    docker compose down -v --remove-orphans
+    docker compose rm -v -f
+    docker volume prune -f
+
+
+### Terminal 2 - Swagger server
+
+Bring up the API code and set the required environment variables to connect to MySQL and Minio 
+
+    # cd <mlx_root_directory>
+    cd api/server/swagger_server
+
+    export MINIO_SERVICE_SERVICE_HOST=localhost
+    export MINIO_SERVICE_SERVICE_PORT=9000
+    export MYSQL_SERVICE_HOST=localhost
+    export MYSQL_SERVICE_PORT=3306
+    export ML_PIPELINE_SERVICE_HOST=UNAVAILABLE
+    export ML_PIPELINE_SERVICE_PORT=UNAVAILABLE
+
+    python3 -m swagger_server
+
+After testing or debugging your code changes, bring down the Swagger Server
+
+    # control + C
+
+### Terminal 3 - Initialize the catalog
+
+First time you bring up the Quickstart for API development, you need to populate the
+MLX Katalog
+
+    # cd <mlx_root_directory>
+    cd quickstart
+    ./init_catalog.sh

--- a/api/README.md
+++ b/api/README.md
@@ -92,9 +92,9 @@ You can test most code changes without a Kubernetes cluster. A K8s cluster is on
 required to `run` the generated sample pipeline code. Running the Quickstart with
 Docker Compose is sufficient to test any `katalog` related API endpoints.
 
-A development setup that works very well requires to 3 shell terminals:
+A development setup that works well requires 3 shell terminals in parallel:
 
-### TERMINAL 1 - Quickstart without `mlx-api` Service
+### TERMINAL 1 - Quickstart without the `mlx-api` Service
 
 Bring up the Quickstart without the `mlx-api` service, since we will run the MLX API
 from our local source code, instead of using the pre-built Docker image `mlexchange/mlx-api:nightly-main`.
@@ -103,6 +103,22 @@ from our local source code, instead of using the pre-built Docker image `mlexcha
     cd quickstart
     
     docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui
+
+When the MLX UI is ready, the log messages should show something like this:
+
+    mlx-ui_1      | The build folder is ready to be deployed.
+    mlx-ui_1      | 
+    mlx-ui_1      | Find out more about deployment here:
+    mlx-ui_1      | 
+    mlx-ui_1      |   bit.ly/CRA-deploy
+    mlx-ui_1      | 
+    mlx-ui_1      | [HPM] Proxy created: /  ->  http://mlx-api
+    mlx-ui_1      | Server listening at http://localhost:3000
+
+Now you could bring up the MLX UI on `localhost` port `80` (not `3000`), but it will not yet be
+connected to the MLX API, which we will start in [TERMINAL 2](#terminal-2---swagger-server)
+
+    http://localhost:80/
 
 After testing or debugging your code changes, bring down the Docker Compose stack:
 
@@ -142,11 +158,12 @@ The terminal should show log messages like these:
     2021/09/27 15:44:48.329 INFO    [flaskapp] Enable cross-origin support with 'flask-cors': origins='*'
     2021/09/27 15:44:48.335 INFO    [waitress] Serving on http://0.0.0.0:8080
 
-Now you can bring up the MLX UI which should be connected to the MLX API on local port `8080`
+Now you can bring up the MLX UI on `localhost` port `80` which should be connected to the
+MLX API on local port `8080`
 
     http://localhost:80/
 
-Or bring up the Swagger API spec on port `8080` to test API endpoints directly
+You can also bring up the Swagger API spec on port `8080` to test API endpoints directly
 
     http://localhost:8080/apis/v1alpha1/ui/
 

--- a/api/README.md
+++ b/api/README.md
@@ -50,6 +50,12 @@ will automatically download the _"correct"_ version of the `swagger-codegen-cli.
 
     python3 -m venv .venv
     source .venv/bin/activate
+
+## Install the Python Package Dependencies
+
+    # cd <mlx_root_dir>
+    # cd api
+
     pip install -r ./requirements.txt
 
 ## (Re-)Generate Swagger Client and Server Code
@@ -62,6 +68,7 @@ will automatically download the _"correct"_ version of the `swagger-codegen-cli.
     docker build -t <your_docker_user_id>/mlx-api-server:0.1 .
     docker login
     docker push <your_docker_user_id>/mlx-api-server:0.1
+    cd ..
 
 ## (Re-)Deploy to Kubernetes Cluster
 
@@ -70,7 +77,7 @@ from `image: docker.io/aipipeline/mlx-api:nightly-master`
 to `image: docker.io/<your_docker_user_id>/mlx-api-server:0.1`
 and then run:
 
-    ./api/deploy.sh
+    ./deploy.sh
 
 or:
 
@@ -85,12 +92,12 @@ Docker Compose is sufficient to test any `katalog` related API endpoints.
 
 A development setup that works very well requires to 3 shell terminals:
 
-### Terminal 1 - Quickstart without `mlx-api` service
+### TERMINAL 1 - Quickstart without `mlx-api` Service
 
 Bring up the Quickstart without the `mlx-api` service, since we will run the MLX API
 from our local source code, instead of using the pre-built Docker image `mlexchange/mlx-api:nightly-main`.
 
-    # cd <mlx_root_directory>
+    # cd <mlx_root_dir>
     cd quickstart
     
     docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui
@@ -108,11 +115,11 @@ Optional, to delete all data in Minio and MySQL, run the following commands:
     docker volume prune -f
 
 
-### Terminal 2 - Swagger server
+### TERMINAL 2 - Swagger Server
 
 Bring up the API code and set the required environment variables to connect to MySQL and Minio 
 
-    # cd <mlx_root_directory>
+    # cd <mlx_root_dir>
     cd api/server/swagger_server
 
     export MINIO_SERVICE_SERVICE_HOST=localhost
@@ -124,14 +131,28 @@ Bring up the API code and set the required environment variables to connect to M
 
     python3 -m swagger_server
 
+The terminal should show log messages like these:
+
+    2021/09/27 15:44:47.575 INFO    [flaskapp] MLX API version: 0.1.29-dont-cache-kfservices
+    2021/09/27 15:44:48.329 INFO    [flaskapp] Enable cross-origin support with 'flask-cors': origins='*'
+    2021/09/27 15:44:48.335 INFO    [waitress] Serving on http://0.0.0.0:8080
+
+Now you can bring up the MLX UI which should be connected to the MLX API on local port `8080`
+
+    http://localhost:80/
+
+Or bring up the Swagger API spec on port `8080` to test API endpoints directly
+
+    http://localhost:8080/apis/v1alpha1/ui/
+
 After testing or debugging your code changes, bring down the Swagger Server
 
     # control + C
 
-### Terminal 3 - Initialize the catalog
+### TERMINAL 3 - Initialize the Catalog
 
-First time you bring up the Quickstart for API development, you need to populate the
-MLX Katalog
+**Note**: The first time you bring up the Quickstart for API development, you need
+to populate the MLX asset catalog
 
     # cd <mlx_root_directory>
     cd quickstart


### PR DESCRIPTION
Excerpt from [api/README.md](https://github.com/ckadner/mlx/tree/api_developer_guide/api#testing-api-code-changes-with-docker-compose) about using Docker Compose for API development:

---

> ## Create a Python Virtual Environment for Development
> 
>     python3 -m venv .venv
>     source .venv/bin/activate
> 
> ## Install the Python Package Dependencies
> 
>     # cd <mlx_root_dir>
>     # cd api
> 
>     pip install -r ./requirements.txt

---


## Testing API Code Changes with Docker Compose

You can test most code changes without a Kubernetes cluster. A K8s cluster is only
required to `run` the generated sample pipeline code. Running the Quickstart with
Docker Compose is sufficient to test any `katalog` related API endpoints.

A development setup that works well requires 3 shell terminals in parallel:

### TERMINAL 1 - Quickstart without the `mlx-api` Service

Bring up the Quickstart without the `mlx-api` service, since we will run the MLX API
from our local source code, instead of using the pre-built Docker image `mlexchange/mlx-api:nightly-main`.

    # cd <mlx_root_dir>
    cd quickstart
    
    docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui

When the MLX UI is ready, the log messages should show something like this:

    mlx-ui_1      | The build folder is ready to be deployed.
    mlx-ui_1      | 
    mlx-ui_1      | Find out more about deployment here:
    mlx-ui_1      | 
    mlx-ui_1      |   bit.ly/CRA-deploy
    mlx-ui_1      | 
    mlx-ui_1      | [HPM] Proxy created: /  ->  http://mlx-api
    mlx-ui_1      | Server listening at http://localhost:3000

Now you could bring up the MLX UI on `localhost` port `80` (not `3000`), but it will not yet be
connected to the MLX API, which we will start in [TERMINAL 2](#terminal-2---swagger-server)

    http://localhost:80/

After testing or debugging your code changes, bring down the Docker Compose stack:

    # control + C 

    docker compose --project-name  no_api  down  minio miniosetup mysql mlx-ui

Optional, to delete all data in Minio and MySQL, run the following commands:

    docker compose down -v --remove-orphans
    docker compose rm -v -f
    docker volume prune -f


### TERMINAL 2 - Swagger Server

Bring up the API code and set the required environment variables to connect to MySQL and Minio.

Make sure to have activated you Python virtual environment with the required package dependencies
installed as described [above](#create-a-python-virtual-environment-for-development).

    # cd <mlx_root_dir>
    cd api/server/swagger_server

    export MINIO_SERVICE_SERVICE_HOST=localhost
    export MINIO_SERVICE_SERVICE_PORT=9000
    export MYSQL_SERVICE_HOST=localhost
    export MYSQL_SERVICE_PORT=3306
    export ML_PIPELINE_SERVICE_HOST=UNAVAILABLE
    export ML_PIPELINE_SERVICE_PORT=UNAVAILABLE

    python3 -m swagger_server

The terminal should show log messages like these:

    2021/09/27 15:44:47.575 INFO    [flaskapp] MLX API version: 0.1.29-dont-cache-kfservices
    2021/09/27 15:44:48.329 INFO    [flaskapp] Enable cross-origin support with 'flask-cors': origins='*'
    2021/09/27 15:44:48.335 INFO    [waitress] Serving on http://0.0.0.0:8080

Now you can bring up the MLX UI on `localhost` port `80` which should be connected to the
MLX API on local port `8080`

    http://localhost:80/

You can also bring up the Swagger API spec on port `8080` to test API endpoints directly

    http://localhost:8080/apis/v1alpha1/ui/

After testing or debugging your code changes, bring down the Swagger Server

    # control + C

### TERMINAL 3 - Initialize the Catalog

**Note**: The first time you bring up the Quickstart for API development, you need
to populate the MLX asset catalog

    # cd <mlx_root_directory>
    cd quickstart
    ./init_catalog.sh



---

@vedantgannu @JAulet @smoleyxd @girigsrini 