### PR TITLE
[UI] Ensure unpublished assets cannot be accessed anonymously

### DIFF
--- a/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaDetailPage.tsx
@@ -39,7 +39,6 @@ function MetaDetailPage(props: MetaDetailPageProps) {
       if (!asset) {
         fetchAssetById(API, type, id)
         .then((asset: any) => {
-          console.log("ASSET: ", asset)
           if (asset === 'Not found' || (asset.publish_approved === 0 && !hasRole(getUserInfo(), 'admin'))) {
             asset.template = undefined
             setAssetNotFound(true)


### PR DESCRIPTION
Added if check to redirect users to a 404 page if the asset they
attempt to access is unpublished and the user is anonymous.

Resolves #207

@ckadner 