### PR TITLE
Sed for linux 

### DIFF
--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -1,8 +1,11 @@
-#!/usr/bin/env -S bash -i
+#!/usr/bin/env bash
 
 # Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# set interactive mode to enable defining a gsed alias
+shopt -s expand_aliases
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then  # Linux
     alias gsed="sed -i"
@@ -58,7 +61,7 @@ html_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    gsed '' '1i\
+    gsed '1i\
     <!--\
      Copyright 2021 The MLX Contributors\
       \
@@ -76,7 +79,7 @@ echo "Adding missing license headers"
 find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.py' -o -name '*.yaml' -o -name '*.yml' -o -name '*.sh' \) -exec bash -c 'hash_comment "$0"' {} \;
 
 # Javascript
-find . -type f -not -path '*/node_modules/*' -a -not -path '*/temp/*' -a -not -path '*/\.*' -a -not -path '*.bundles.js' -a \( -name '*.js' -o -name '*.ts' \) -exec bash -c 'slash_comment "$0"' {} \;
+find . -type f -not -path '*/node_modules/*' -a -not -path '*/temp/*' -a -not -path '*/\.*' -a -not -path '*.bundle.js' -a \( -name '*.js' -o -name '*.ts' \) -exec bash -c 'slash_comment "$0"' {} \;
 
 # CSS
 find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.css' -o -name '*.tsx' \) -exec bash -c 'css_comment "$0"' {} \;

--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -84,7 +84,7 @@ echo "Adding missing license headers"
 find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.py' -o -name '*.yaml' -o -name '*.yml' -o -name '*.sh' \) -exec bash -c 'hash_comment "$0"' {} \;
 
 # Javascript
-find . -type f -not -path '*/node_modules/*' -a -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.js' -o -name '*.ts' \) -exec bash -c 'slash_comment "$0"' {} \;
+find . -type f -not -path '*/node_modules/*' -a -not -path '*/temp/*' -a -not -path '*/\.*' -a -not -path '*.bundles.js' -a \( -name '*.js' -o -name '*.ts' \) -exec bash -c 'slash_comment "$0"' {} \;
 
 # CSS
 find . -type f -not -path '*/temp/*' -a -not -path '*/\.*' -a \( -name '*.css' -o -name '*.tsx' \) -exec bash -c 'css_comment "$0"' {} \;

--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -1,36 +1,30 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S bash -i
 
 # Copyright 2021 The MLX Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
-sed_for_linux() {
-  sed -i '1i\
-  # Copyright 2021 The MLX Contributors\
-  #\
-  # SPDX-License-Identifier: Apache-2.0\
-  ' "$1"
-}
-
-sed_for_macos() {
-  sed -i '' '1i\
-  # Copyright 2021 The MLX Contributors\
-  #\
-  # SPDX-License-Identifier: Apache-2.0\
-  ' "$1"
-}
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then  # Linux
+    alias gsed="sed -i"
+elif [[ "$OSTYPE" == "darwin"* ]]; then  # macOS
+    alias gsed="sed -i ''"
+elif [[ "$OSTYPE" == "cygwin" ]]; then  # POSIX compatible emulation for Windows
+    alias gsed="sed -i"
+else
+    echo "FAILED. OS not compatible with script '/hack/add_license_headers.sh'"
+    exit 1
+fi
+export gsed
 
 hash_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      $(sed_for_linux $1)
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      $(sed_for_macos $1)
-    else
-      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
-    fi
+    gsed '1i\
+    # Copyright 2021 The MLX Contributors\
+    #\
+    # SPDX-License-Identifier: Apache-2.0\
+    ' "$1"
   fi
 }
 
@@ -38,13 +32,11 @@ slash_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      $(sed_for_linux $1)
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      $(sed_for_macos $1)
-    else
-      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
-    fi
+    gsed '1i\
+    // Copyright 2021 The MLX Contributors\
+    //\
+    // SPDX-License-Identifier: Apache-2.0\
+    ' "$1"
   fi
 }
 
@@ -52,13 +44,13 @@ css_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      $(sed_for_linux $1)
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      $(sed_for_macos $1)
-    else
-      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
-    fi
+    gsed '1i\
+    /*\
+    * Copyright 2021 The MLX Contributors\
+    *\
+    * SPDX-License-Identifier: Apache-2.0\
+    */\
+    ' "$1"
   fi
 }
 
@@ -66,17 +58,17 @@ html_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-      $(sed_for_linux $1)
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      $(sed_for_macos $1)
-    else
-      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
-    fi
+    gsed '' '1i\
+    <!--\
+     Copyright 2021 The MLX Contributors\
+      \
+      SPDX-License-Identifier: Apache-2.0\
+    -->\
+    ' "$1"
   fi
 }
 
-export -f sed_for_linux sed_for_macos hash_comment slash_comment css_comment html_comment
+export -f hash_comment slash_comment css_comment html_comment
 
 echo "Adding missing license headers"
 

--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -4,15 +4,33 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+sed_for_linux() {
+  sed -i '1i\
+  # Copyright 2021 The MLX Contributors\
+  #\
+  # SPDX-License-Identifier: Apache-2.0\
+  ' "$1"
+}
+
+sed_for_macos() {
+  sed -i '' '1i\
+  # Copyright 2021 The MLX Contributors\
+  #\
+  # SPDX-License-Identifier: Apache-2.0\
+  ' "$1"
+}
+
 hash_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    sed -i '' '1i\
-    # Copyright 2021 The MLX Contributors\
-    #\
-    # SPDX-License-Identifier: Apache-2.0\
-    ' "$1"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      $(sed_for_linux $1)
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      $(sed_for_macos $1)
+    else
+      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
+    fi
   fi
 }
 
@@ -20,11 +38,13 @@ slash_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    sed -i '' '1i\
-    // Copyright 2021 The MLX Contributors\
-    //\
-    // SPDX-License-Identifier: Apache-2.0\
-    ' "$1"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      $(sed_for_linux $1)
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      $(sed_for_macos $1)
+    else
+      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
+    fi
   fi
 }
 
@@ -32,13 +52,13 @@ css_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    sed -i '' '1i\
-    /*\
-    * Copyright 2021 The MLX Contributors\
-    *\
-    * SPDX-License-Identifier: Apache-2.0\
-    */\
-    ' "$1"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      $(sed_for_linux $1)
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      $(sed_for_macos $1)
+    else
+      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
+    fi
   fi
 }
 
@@ -46,17 +66,17 @@ html_comment () {
   echo "$1"
   if ! grep -q "SPDX-License-Identifier" "$1"
   then
-    sed -i '' '1i\
-    <!--\
-     Copyright 2021 The MLX Contributors\
-      \
-      SPDX-License-Identifier: Apache-2.0\
-    -->\
-    ' "$1"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+      $(sed_for_linux $1)
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      $(sed_for_macos $1)
+    else
+      echo "FAILED | OS not compatible | Check /hack/add_license_headers.sh "
+    fi
   fi
 }
 
-export -f hash_comment slash_comment css_comment html_comment
+export -f sed_for_linux sed_for_macos hash_comment slash_comment css_comment html_comment
 
 echo "Adding missing license headers"
 

--- a/hack/regenerate_catalog_upload_json.py
+++ b/hack/regenerate_catalog_upload_json.py
@@ -1,3 +1,7 @@
+  # Copyright 2021 The MLX Contributors
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  
 #!/usr/bin/env python3
 
 # Copyright 2021 IBM Corporation

--- a/hack/regenerate_catalog_upload_json.py
+++ b/hack/regenerate_catalog_upload_json.py
@@ -1,22 +1,8 @@
-  # Copyright 2021 The MLX Contributors
-  #
-  # SPDX-License-Identifier: Apache-2.0
-  
 #!/usr/bin/env python3
 
-# Copyright 2021 IBM Corporation
+# Copyright 2021 The MLX Contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from __future__ import print_function
 


### PR DESCRIPTION
Fixes updating licensing by running the correct sed command corresponding to Linux and MacOS
For readability- Sed commands are in separate functions, called by each `xxxx_comment()` function in add_license_headers.sh during execution.
Throws error statement without exit code, indicating the command isn't working due to OS limitations of sed (i.e. user is using Windows)

@ckadner 