### PR TITLE
Disable UI cache in Quickstart

### DIFF
--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -79,13 +79,15 @@ services:
       - "80:3000"
     environment:
       REACT_APP_BRAND: "Machine Learning Exchange"
-      REACT_APP_RUN: "false"
       REACT_APP_UPLOAD: "true"
+      REACT_APP_RUN: "false"
       REACT_APP_BASE_PATH: ""
       REACT_APP_API: "${DOCKER_HOST_IP:-localhost}:8080"
       REACT_APP_KFP: ""
       REACT_APP_DISABLE_LOGIN: "true"
       REACT_APP_GTM_ID: "${GTM_ID}"
+      REACT_APP_TTL: "0"
+      REACT_APP_CACHE_INTERVAL: "0"
 
   catalog:
     image: curlimages/curl


### PR DESCRIPTION
With Docker Compose, the API and UI run locally and the API has caching for GET requests. So there is no real advantage in having yet another layer of caching in the UI. 

In fact, the UI cache is often getting in the way of testing the catalog by adding or deleting assets.
