### PR TITLE
Update README export commands for disabling UI cache

### DIFF
--- a/dashboard/origin-mlx/README.md
+++ b/dashboard/origin-mlx/README.md
@@ -140,6 +140,8 @@ export REACT_APP_API="localhost:8080"
 export REACT_APP_RUN="false"
 export REACT_APP_UPLOAD="true"
 export REACT_APP_DISABLE_LOGIN="true"
+export REACT_APP_TTL="0"                # Disable the cache
+export REACT_APP_CACHE_INTERVAL="0"     # Ignore checking cache
 ```
 
 Start the MLX Web UI server:


### PR DESCRIPTION
Two export commands have been added in relation to cache and cache intervals. This updates the README to reflect those effects on the Development Setup