### PR TITLE
Removed Dashboard Dependency on Catalog Service

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -102,7 +102,7 @@ from our local source code, instead of using the pre-built Docker image `mlexcha
     # cd <mlx_root_dir>
     cd quickstart
     
-    docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui
+    docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui dashboard
 
 When the MLX UI is ready, the log messages should show something like this:
 
@@ -124,7 +124,7 @@ After testing or debugging your code changes, bring down the Docker Compose stac
 
     # control + C 
 
-    docker compose --project-name  no_api  down  minio miniosetup mysql mlx-ui
+    docker compose --project-name  no_api  down
 
 Optional, to delete all data in Minio and MySQL, run the following commands:
 

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -109,7 +109,6 @@ services:
     image: curlimages/curl
     depends_on:
       - mlx-ui
-      #- catalog        # There is no catalog in API dev setup, so message never appears.
     entrypoint: ["/bin/sh","-c"]
     command:
     - |

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
     image: curlimages/curl
     depends_on:
       - mlx-ui
-      - catalog
+      #- catalog        # There is no catalog in API dev setup, so message never appears.
     entrypoint: ["/bin/sh","-c"]
     command:
     - |


### PR DESCRIPTION
**Description of changes:** 
* Edited docker-compose.yaml to remove catalog
  dependency from dashboard service
* Edited api/README.md to correct docker compose
  instructions

Modified command to add `dashboard` service.

```
docker compose --project-name  no_api   up   minio miniosetup mysql mlx-ui dashboard
```

Console Output:
```
no_api-mlx-ui-1      | [HPM] Proxy created: /  ->  http://mlx-api
no_api-mlx-ui-1      | Server listening at http://localhost:3000
no_api-dashboard-1   |
no_api-dashboard-1   | ================================================
no_api-dashboard-1   |  Open the MLX Dashboard at http://localhost:80/
no_api-dashboard-1   | ================================================
```

Resolves #274

@ckadner Please Review