### PR TITLE
Disable run in Quickstart (again)

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -21,7 +21,8 @@ To deploy MLX locally with Kubernetes on Docker (KIND) follow this
 In a nutshell, run these two commands and bring up MLX in your browser when
 you see the log message `Open the MLX Dashboard at http://localhost:80/`:
 
-    wget https://raw.githubusercontent.com/machine-learning-exchange/mlx/main/quickstart/docker-compose.yaml
+    curl -O https://raw.githubusercontent.com/machine-learning-exchange/mlx/main/quickstart/docker-compose.yaml
+
     docker compose up
 
 
@@ -43,7 +44,7 @@ default of 2 GB memory to 4 GB.
 
 Either, download the `docker-compose.yaml` directly:
 
-    wget https://raw.githubusercontent.com/machine-learning-exchange/mlx/main/quickstart/docker-compose.yaml
+    curl -O https://raw.githubusercontent.com/machine-learning-exchange/mlx/main/quickstart/docker-compose.yaml
 
 Or, clone this repository and navigate to the `quickstart` folder:
 

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -94,6 +94,7 @@ services:
       HEALTH_API: "http://mlx-api:8080/apis/v1alpha1/health_check?check_database=true&check_object_store=true"
       UPLOAD_API: "http://mlx-api:8080/apis/v1alpha1/catalog/upload_from_url"
       CATALOG_URL: "https://raw.githubusercontent.com/machine-learning-exchange/mlx/main/bootstrapper/catalog_upload.json"
+      SETTINGS_API: "http://mlx-api:8080/apis/v1alpha1/settings"
     command:
     - |
       until curl -I -s "$${HEALTH_API}" | grep -q "200 OK"; do
@@ -104,6 +105,10 @@ services:
         -H "Content-Type: multipart/form-data" \
         -F url="$${CATALOG_URL}" \
         -s "$${UPLOAD_API}" | grep -iE "total_|error"
+      curl -X PUT \
+        -H 'Content-Type: application/json' \
+        -d '{"Execution enabled": false, "Inference Services": false}' \
+        -s "$${SETTINGS_API}" -o /dev/null --show-error
 
   dashboard:
     image: curlimages/curl


### PR DESCRIPTION
After PR #281 the Quickstart started to show the `LAUNCH` tabs even though the `mlx-ui` service has `REACT_APP_RUN: "false"`. So this PR is adding back the API call to disable the RUN setting.