### PR TITLE
Support Codegen for Git Bash on Windows

### DIFF
--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -51,6 +51,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # macOS
     alias gsed="sed -i ''"
 elif [[ "$OSTYPE" == "cygwin" ]]; then  # POSIX compatible emulation for Windows
     alias gsed="sed -i"
+elif [[ "$OSTYPE" == "msys"* ]]; then  # Git Bash (Windows)
+    alias gsed="sed -i"
 else
     echo "FAILED. OS not compatible with script '${BASH_SOURCE[0]}'"
     exit 1

--- a/tools/bash/add_license_headers.sh
+++ b/tools/bash/add_license_headers.sh
@@ -13,6 +13,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then  # macOS
     alias gsed="sed -i ''"
 elif [[ "$OSTYPE" == "cygwin" ]]; then  # POSIX compatible emulation for Windows
     alias gsed="sed -i"
+elif [[ "$OSTYPE" == "msys"* ]]; then  # Git Bash (Windows)
+    alias gsed="sed -i"
 else
     echo "FAILED. OS not compatible with script '${BASH_SOURCE[0]}'"
     exit 1


### PR DESCRIPTION
Resolves #291

Modified `generate_code.sh` and `add_liscence_headers.sh` under `api` and `tools` respectively to include Windows Git Bash as a valid OS Type.

F.Y.I: @ckadner 