### PR TITLE
Update prerequisites in with-kubeflow deployment doc

### DIFF
--- a/docs/mlx-install-with-kubeflow.md
+++ b/docs/mlx-install-with-kubeflow.md
@@ -4,7 +4,7 @@
 * An existing Kubernetes cluster. Version 1.17+
 * The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
-* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
+* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
 * [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
    * Kustomize v3.2.0 quick install:
    ```

--- a/docs/mlx-install-with-kubeflow.md
+++ b/docs/mlx-install-with-kubeflow.md
@@ -2,10 +2,17 @@
 
 ## Prerequisites
 * An existing Kubernetes cluster. Version 1.17+
-* The minimum capacity requirement for MLX is 8 vCPUs and 16GB RAM
-* If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using [IBM Cloud Public](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
-* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/containers?topic=containers-openshift_tutorial)
-* [`kustomize v3.0+`](https://kubernetes-sigs.github.io/kustomize/installation/) is installed
+* The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
+* If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
+* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
+* [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
+   * Kustomize v3.2.0 quick install:
+   ```
+   OS=$(uname) 
+   curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v3.2.0/kustomize_3.2.0_${OS}_amd64 --output kustomize
+   chmod +x kustomize
+   mv kustomize /usr/local/bin
+   ```
 
 ## Install Kfctl
 

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -4,7 +4,7 @@
 * An existing Kubernetes cluster. Version 1.17+
 * The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
-* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
+* If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
 * [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
    * Kustomize v3.2.0 quick install:
    ```


### PR DESCRIPTION
Contributes to #304 

I copied the same prerequisites from the [Deploy MLX on an existing Kubernetes cluster](https://github.com/machine-learning-exchange/mlx/blob/main/docs/mlx-setup.md#prerequisites) page, I figured they should provide exactly the same information (e.g. `kustomize` version)