### PR TITLE
Update Kubernetes version boundaries in deployment docs (#318)

### DIFF
--- a/docs/install-mlx-on-kind.md
+++ b/docs/install-mlx-on-kind.md
@@ -40,9 +40,9 @@ you could download the `kustomize` `v3.2.0` binary as described
 
 Increase the default resources for Docker:
 
-- CPUs: 8 Cores
-- Memory: 16 GB RAM
-- Disk: 32+ GB
+- **CPUs**: 8 Cores
+- **Memory**: 16 GB RAM
+- **Disk**: 32+ GB
 
 **Note**: We found that on older laptops, like a 2016 MacBook Pro (2.7 GHz i7, 16 GB RAM) the MLX
 deployment on KIND may require to give all available resources to the Docker daemon in order to be
@@ -54,7 +54,7 @@ other application to crash.
 ## Create KIND Cluster
 
 ```Bash
-kind create cluster --name mlx
+kind create cluster --name mlx --image kindest/node:v1.21.12
 kubectl cluster-info --context kind-mlx
 kubectl get pods --all-namespaces
 ```

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -4,9 +4,10 @@
 * An existing Kubernetes cluster:
    - **Min version: 1.17**
    - **Max version: 1.21** 
-* The minimum recommended capacity requirement for MLX are: 
-   - **CPUs/Cores: 8**
-   - **Memory (RAM): 16GB**
+* The recommended minimum capacity requirement for MLX are: 
+   - **CPUs**: 8 Cores
+   - **Memory**: 16 GB RAM
+   - **Disk**: 32+ GB
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
 * [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
@@ -55,13 +56,19 @@ kustomize build example | kubectl delete -f -
 
 ## Troubleshooting
 
-- If you see errors like these during the deployment, it may be because of a unsupported Kubernetes version. Check the [Prerequisites](#prerequisites) for the supported Kubernetes versions.
-```
-# while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
-...
-unable to recognize "STDIN": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
-unable to recognize "STDIN": no matches for kind "RoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
-unable to recognize "STDIN": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
-unable to recognize "STDIN": no matches for kind "EnvoyFilter" in version "networking.istio.io/v1alpha3"
-...
-```
+- If you see errors like these during the deployment, it may be because of a unsupported Kubernetes version.
+  Check the [Prerequisites](#prerequisites) for the supported Kubernetes versions.
+  
+  ```
+  # while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+  ...
+  unable to recognize "STDIN": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
+  unable to recognize "STDIN": no matches for kind "RoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
+  unable to recognize "STDIN": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
+  unable to recognize "STDIN": no matches for kind "EnvoyFilter" in version "networking.istio.io/v1alpha3"
+  ...
+  ```
+  To find your Kubernetes server version, run `kubectl version | grep Server`:
+  ```
+  Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.12", ...
+  ```

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -1,12 +1,12 @@
 # Deploy MLX on an existing Kubernetes cluster
 
 ## Prerequisites
-* An existing Kubernetes cluster must be:
-   - **Versions 1.17 up to 1.21** 
+* An existing Kubernetes cluster:
+   - **Min version: 1.17**
+   - **Max version: 1.21** 
 * The minimum recommended capacity requirement for MLX are: 
-   - **8 vCPUs**
-   - **16GB RAM**
-* The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
+   - **CPUs/Cores: 8**
+   - **Memory (RAM): 16GB**
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
 * [`kustomize v3.2.0`](https://github.com/kubernetes-sigs/kustomize/releases/tag/v3.2.0) is installed
@@ -53,9 +53,12 @@ To delete this MLX deployment, run the following commands in the same manifests 
 kustomize build example | kubectl delete -f -
 ```
 
-## Troubleshoot
-- In order to avoid the error below please use Kubernetes version detailed in the prerequisites
+## Troubleshooting
+
+- If you see errors like these during the deployment, it may be because of a unsupported Kubernetes version. Check the [Prerequisites](#prerequisites) for the supported Kubernetes versions.
 ```
+# while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+...
 unable to recognize "STDIN": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
 unable to recognize "STDIN": no matches for kind "RoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
 unable to recognize "STDIN": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -1,7 +1,11 @@
 # Deploy MLX on an existing Kubernetes cluster
 
 ## Prerequisites
-* An existing Kubernetes cluster. Version 1.17+
+* An existing Kubernetes cluster must be:
+   - **Versions 1.17 up to 1.21** 
+* The minimum recommended capacity requirement for MLX are: 
+   - **8 vCPUs**
+   - **16GB RAM**
 * The minimum recommended capacity requirement for MLX is 8 vCPUs and 16GB RAM
 * If you are using IBM Cloud, follow the appropriate instructions for standing up your Kubernetes cluster using the [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-cs_cluster_tutorial#cs_cluster_tutorial)
 * If you are using OpenShift on IBM Cloud, please follow the instructions for standing up your [IBM Cloud Red Hat OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_tutorial)
@@ -47,4 +51,14 @@ To delete this MLX deployment, run the following commands in the same manifests 
 
 ```
 kustomize build example | kubectl delete -f -
+```
+
+## Troubleshoot
+- In order to avoid the error below please use Kubernetes version detailed in the prerequisites
+```
+unable to recognize "STDIN": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
+unable to recognize "STDIN": no matches for kind "RoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
+unable to recognize "STDIN": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
+unable to recognize "STDIN": no matches for kind "EnvoyFilter" in version "networking.istio.io/v1alpha3"
+...
 ```


### PR DESCRIPTION
This PR includes updating setup documentation to show appropriate **Kubernetes versions** that MLX currently supports as well as **Troubleshooting** section 

/assign @ckadner 

Related #318