### PR TITLE
Fix startup errors in `mlx-ui` Docker container (prereg to run on OpenShift)

### DIFF
--- a/dashboard/origin-mlx/Dockerfile
+++ b/dashboard/origin-mlx/Dockerfile
@@ -19,4 +19,4 @@ RUN cd server && npm install && npm run build
 
 # start app
 ENV NODE_ENV=production
-CMD ["sh", "-c", "npm run build && mv build/ proc/ && node server/dist/server.js proc/ $PORT"]
+CMD ["sh", "-c", "npm run build && node server/dist/server.js build/ $PORT"]

--- a/dashboard/origin-mlx/src/components/Detail/DatasetDetail.tsx
+++ b/dashboard/origin-mlx/src/components/Detail/DatasetDetail.tsx
@@ -14,7 +14,6 @@ import { getUserInfo, hasRole } from '../../lib/util';
 import RunView from '../RunView'
 import RelatedAssetView from '../RelatedAssetView';
 import MarkdownViewer from '../MarkdownViewer';
-import LoadingMessage from '../LoadingMessage';
 import MetadataView from '../MetadataView';
 
 const isAdmin = hasRole(getUserInfo(), 'admin');

--- a/dashboard/origin-mlx/src/components/Detail/KFServingDetail.tsx
+++ b/dashboard/origin-mlx/src/components/Detail/KFServingDetail.tsx
@@ -191,7 +191,7 @@ export default class KFServingDetail extends React.Component<KFServingDetailProp
     }
     else {
       predictorTimestamp = service.metadata.creationTimestamp
-      predictorStatusIcon = service.status.activeModelState == "Ready" 
+      predictorStatusIcon = service.status.activeModelState === "Ready" 
         ? <CheckCircleIcon className="check-icon"/>
         : <ErrorIcon className="error-icon"/>
     }


### PR DESCRIPTION
With these 3 file tweaks, this currently is starting up successfully on an OpenShift 4.8 cluster.

- don't `mv build/ proc/` use `build` folder directly for running the node application

Resolves #337

Related https://github.com/IBM/manifests/pull/41