### PR TITLE
fix selected assets show up in different menus

### DIFF
--- a/dashboard/origin-mlx/src/pages/MetaAllPage.tsx
+++ b/dashboard/origin-mlx/src/pages/MetaAllPage.tsx
@@ -188,7 +188,7 @@ function MetaAllPage(props: MetaAllPageProps) {
         <Paper>
           <EnhancedToolbar
             type={type}
-            numSelected={pipeline.components.length}
+            numSelected={selected.size}
             toggleModal={(e: never) => {}}
           />
           <Table>


### PR DESCRIPTION
fix https://github.com/machine-learning-exchange/mlx/issues/263

When the user switches to a different asset page, they should see zero assets of that type selected.