### PR TITLE
Update MLX setup instructions for KF 1.5

### DIFF
--- a/docs/install-mlx-on-kind.md
+++ b/docs/install-mlx-on-kind.md
@@ -63,7 +63,7 @@ kubectl get pods --all-namespaces
 ## Deploy MLX (Single-User)
 
 ```Bash
-git clone https://github.com/IBM/manifests -b v1.4.0-mlx
+git clone https://github.com/IBM/manifests -b v1.5-branch
 cd manifests
 
 # run the below command two times if the CRDs take too long to provision
@@ -80,7 +80,8 @@ done
 kubectl get pods --all-namespaces
 
 # make the MLX UI available to your local browser on http://localhost:3000/
-kubectl port-forward -n istio-system svc/istio-ingressgateway 3000:80 &
+kubectl wait -n kubeflow --for=condition=ready pod -l service=mlx-ui && \
+  kubectl port-forward -n istio-system svc/istio-ingressgateway 3000:80 &
 ```
 
 Now paste the URL http://localhost:3000/login into your browser and proceed to

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -1,9 +1,10 @@
 # Deploy MLX on an existing Kubernetes cluster
 
 ## Prerequisites
+
 * An existing Kubernetes cluster:
    - **Min version: 1.17**
-   - **Max version: 1.21** 
+   - **Max version: 1.23** 
 * The recommended minimum capacity requirement for MLX are: 
    - **CPUs**: 8 Cores
    - **Memory**: 16 GB RAM
@@ -19,9 +20,9 @@
    mv kustomize /usr/local/bin
    ```
 
-## Deploy
+## Deployment
 
-To deploy the MLX single-user mode on an existing Kubernetes Cluster, clone the MLX manifests and deploy it with Kustomize. 
+To deploy the MLX **single-user** mode on an existing Kubernetes Cluster, clone the MLX manifests and deploy it with Kustomize. 
 
 This MLX deployment includes:
 - [Istio](https://istio.io/)
@@ -30,11 +31,33 @@ This MLX deployment includes:
 - [Datashim](https://datashim-io.github.io/datashim/) to provide access to S3 and NFS Datasets within pods
 - MLX API and UI
 
+**Note:** Before deploying MLX on OpenShift on Fyre, you need to install a persistent
+storage provider like [Portworx](https://docs.portworx.com/install-portworx/openshift/)
+and set it as the `default` storage class. This is only required to support mounting
+Persistent Volumes for Datasets using Datashim.
+
+To deploy MLX on your Kubernetes or OpenShift cluster, first set the `MLX_DEPLOYMENT_TYPE`
+environment variable based on your Kubernetes service provider by uncommenting
+one of the `export` commands below:
+
+```Shell
+# export MLX_DEPLOYMENT_TYPE=mlx-single-ibmcloud            # IBM Cloud - Kubernetes
+# export MLX_DEPLOYMENT_TYPE=mlx-single-ibmcloud-openshift  # IBM Cloud - OpenShift
+# export MLX_DEPLOYMENT_TYPE=mlx-single-fyre-openshift      # IBM Fyre - OpenShift
+
+echo "MLX deployment type: ${MLX_DEPLOYMENT_TYPE:-"UNDEFINED"}"
+```
+
+Then clone the [IBM/manifest](https://github.com/IBM/manifests/tree/v1.5-branch)
+repository and apply the manifests to your cluster:
+
 ```shell
-git clone https://github.com/machine-learning-exchange/manifests -b mlx-single-user
-cd manifests
-# run the below command two times if the CRDs take too long to provision.
-while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+# clone the manifest repo
+git clone https://github.com/IBM/manifests -b v1.5-branch && cd manifests
+
+# run the following command twice if the CRDs take too long to provision
+while ! kustomize build ${MLX_DEPLOYMENT_TYPE} | \
+  kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
 ```
 
 Then access the MLX web page on http://<cluster_node_ip>:30380/mlx/
@@ -44,14 +67,16 @@ This MLX deployment doesn't include or support:
 - Multi-user mode
 - Istio mutual TLS
 
-To get these features, please install the additional plugins by following the instructions for [MLX deployment an existing Kubeflow cluster](/docs/install-mlx-on-kubeflow.md#deploy-mlx-on-an-existing-kubeflow-cluster).
+To get those features, please install the additional plugins by following the instructions for
+[MLX deployment an existing Kubeflow cluster](/docs/install-mlx-on-kubeflow.md#deploy-mlx-on-an-existing-kubeflow-cluster).
 
-## Delete the MLX deployment
+
+## Deleting the MLX Deployment
 
 To delete this MLX deployment, run the following commands in the same manifests folder.
 
-```
-kustomize build example | kubectl delete -f -
+```Shell
+kustomize build ${MLX_DEPLOYMENT_TYPE} | kubectl delete -f -
 ```
 
 ## Troubleshooting

--- a/docs/mlx-setup.md
+++ b/docs/mlx-setup.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 * An existing Kubernetes cluster:
-   - **Min version: 1.17**
-   - **Max version: 1.23** 
+   - **Min version: 1.21**
+   - **Max version: 1.21** 
 * The recommended minimum capacity requirement for MLX are: 
    - **CPUs**: 8 Cores
    - **Memory**: 16 GB RAM

--- a/docs/mlx-workshop.md
+++ b/docs/mlx-workshop.md
@@ -202,7 +202,8 @@ For MLX on KIND we need to make the port available on localhost by running the
 following command:
 
 ```Bash
-kubectl port-forward svc/codenet-language-classification 5000:5000
+kubectl wait --for=condition=ready pod -l app=codenet-language-classification && \
+  kubectl port-forward svc/codenet-language-classification 5000:5000
 ```
 
 Now we should be able to access the UI page for the deployed model by pasting


### PR DESCRIPTION
Update the MLX installation instructions for Kubeflow 1.5

Tested Kubernetes providers:
* IBM Cloud Kubernetes service
* IBM Cloud OpenShift
* IBM Fyre OpenShift

Related:
* https://github.com/IBM/manifests/pull/41
* https://github.com/IBM/manifests/pull/44

/cc @Tomcli @yhwang @jbusche @rafvasq 

