### PR TITLE
Add v0.2.0 tag to pipeline template images

### DIFF
--- a/api/server/swagger_server/code_templates/serve_kfserving.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/serve_kfserving.TEMPLATE.py
@@ -32,7 +32,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='tomcli/model-config',
+        image='mlexchange/model-config:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',

--- a/api/server/swagger_server/code_templates/serve_knative.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/serve_knative.TEMPLATE.py
@@ -27,7 +27,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='tomcli/model-config',
+        image='mlexchange/model-config:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',
@@ -43,7 +43,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_deployment = dsl.ContainerOp(
         name='knative_model_deployment',
-        image='aipipeline/knative-model-deploy',
+        image='mlexchange/knative-model-deploy:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'knative_deployment.py',

--- a/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
@@ -27,7 +27,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='aipipeline/model-config',
+        image='mlexchange/model-config:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',
@@ -42,7 +42,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_deployment = dsl.ContainerOp(
         name='k8s_model_deployment',
-        image='aipipeline/deployment-k8s-remote',
+        image='mlexchange/deployment-k8s-remote:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'kube_deployment.py',

--- a/api/server/swagger_server/code_templates/train_watsonml.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/train_watsonml.TEMPLATE.py
@@ -31,7 +31,7 @@ def model_pipeline(model_id='${model_identifier}'):
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='tomcli/model-config:latest',
+        image='mlexchange/model-config:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',

--- a/api/server/swagger_server/code_templates/train_watsonml_w_credentials.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/train_watsonml_w_credentials.TEMPLATE.py
@@ -32,7 +32,7 @@ def model_pipeline(model_id='${model_identifier}',
 
     model_config = dsl.ContainerOp(
         name='model_config',
-        image='aipipeline/model-config:latest',
+        image='mlexchange/model-config:v0.2.0',
         command=['python'],
         arguments=[
             '-u', 'model-config.py',


### PR DESCRIPTION
Add `v0.2.0` tag to container images used in pipeline templates, so that future changes to those components won't break old versions (`v0.1.0` and `v0.2.0`) of MLX.

/cc @rafvasq 
/cc @Tomcli 