### PR TITLE
Deploy model with `container_port` from model YAML

### DIFF
--- a/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
+++ b/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py
@@ -1,6 +1,6 @@
 # Copyright 2021 The MLX Contributors
-# 
-# SPDX-License-Identifier: Apache-2.0 
+#
+# SPDX-License-Identifier: Apache-2.0
 
 from kfp import dsl
 from kfp_tekton.compiler import TektonCompiler
@@ -36,7 +36,8 @@ def model_pipeline(model_id='${model_identifier}'):
         ],
         file_outputs={
             'model-serving-image': '/tmp/model_serving_image',
-            'deployment-name': '/tmp/deployment_name'
+            'deployment-name': '/tmp/deployment_name',
+            'container-port': '/tmp/container_port'
         }
     )
 
@@ -47,7 +48,8 @@ def model_pipeline(model_id='${model_identifier}'):
         arguments=[
             '-u', 'kube_deployment.py',
             '--model_serving_image', model_config.outputs['model-serving-image'],
-            '--deployment_name', model_config.outputs['deployment-name']
+            '--deployment_name', model_config.outputs['deployment-name'],
+            '--container_port', model_config.outputs['container-port'],
         ],
         file_outputs={
             'output': '/tmp/log.txt'

--- a/models/README.md
+++ b/models/README.md
@@ -22,7 +22,7 @@ The [template](template.yaml) describes the metadata spec:
 
 - **(Required)**: Fields that are Always required in all condition.
 - **(Required for xxx)**: Fields that are required when trainable/servable or certain storage type is specified.
-- **(optional)**: Fields that can be omit, but do not put empty strings since it will overwrite the default values.
+- **(optional)**: Fields that can be omitted, but do not put empty strings since it will overwrite the default values.
 
 Or take a look at the 
 [samples](https://github.com/machine-learning-exchange/katalog/tree/main/model-samples) 
@@ -109,6 +109,7 @@ serve:
     - knative
   serving_container_image:
     container_image_url: <model_docker_image>
+    container_port: 5000
 ```
 
 ## Register a Model

--- a/models/template.yaml
+++ b/models/template.yaml
@@ -152,6 +152,7 @@ train:
 #       path: (Optional) Servable model path in the user local machine
 #   serving_container_image: (Required for container type)
 #     container_image_url: (Required for container type) Container image to serve the model.
+#     container_port: (Optional) Container port serving inferencing request. Default: 5000
 #     container_store: (Optional) container_store name
 
 serve:
@@ -170,6 +171,7 @@ serve:
       path: /local/1.0/assets/
   serving_container_image:
     container_image_url: "codait/max-facial-age-estimator:latest"
+    container_port: "5000"
     container_store: container_store
 
 # data (Optional) metadata for model training data


### PR DESCRIPTION
Currently, when models are deployed via the "Launch" tab of the MLX UI, the container port is fixed, assumed to be `5000`. This works for the containerized MAX models, all of which serve inferencing requests on port 5000. However any other models to be registered in MLX that are not listening on port 5000 would have to be rebuild before they can be registered and deployed in MLX.

This PR makes use of a new optional field to the model YAML to allow users to specify the port on which the containerized model listens to inferencing requests.

There is a related [PR `#75`](https://github.com/machine-learning-exchange/katalog/pull/75) on the `katalog` repo to use the `container_port` parameter from the model YAML in the [`model-config` component](https://github.com/ckadner/katalog/blob/model-container-port/component-samples/model-config/src/model-config.py#L167) that is then used in the [model deployment pipeline](https://github.com/ckadner/mlx/blob/model-container-port/api/server/swagger_server/code_templates/serve_kubernetes.TEMPLATE.py#L40-L52) in MLX.

/cc @Tomcli @rafvasq 